### PR TITLE
Feat: 시큐리티 예외 처리 + 토큰 재발급 + 로그아웃

### DIFF
--- a/api/src/main/java/kr/co/readingtown/handler/OAuth2LoginSuccessHandler.java
+++ b/api/src/main/java/kr/co/readingtown/handler/OAuth2LoginSuccessHandler.java
@@ -1,11 +1,11 @@
 package kr.co.readingtown.handler;
 
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import kr.co.readingtown.authentication.domain.CustomOAuth2User;
 import kr.co.readingtown.authentication.jwt.TokenProvider;
+import kr.co.readingtown.common.util.CookieUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -18,6 +18,7 @@ import java.io.IOException;
 public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final TokenProvider tokenProvider;
+    private final CookieUtil cookieUtil;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request,
@@ -29,22 +30,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         String accessToken = tokenProvider.createAccessToken(oauthUser.getProvider(), oauthUser.getName());
         String refreshToken = tokenProvider.createRefreshToken(oauthUser.getProvider(), oauthUser.getName());
 
-        // accessToken 쿠키 설정
-        Cookie accessTokenCookie = new Cookie("access_token", accessToken);
-        // accessTokenCookie.setHttpOnly(true);
-        // accessTokenCookie.setSecure(true);
-        accessTokenCookie.setPath("/");
-        accessTokenCookie.setMaxAge(15 * 60);
-
-        // refreshToken 쿠키 설정
-        Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken);
-        // refreshTokenCookie.setHttpOnly(true);
-        // refreshTokenCookie.setSecure(true);
-        refreshTokenCookie.setPath("/");
-        refreshTokenCookie.setMaxAge(7 * 24 * 60 * 60);
-
-        response.addCookie(accessTokenCookie);
-        response.addCookie(refreshTokenCookie);
+        cookieUtil.saveTokenToCookie(response, accessToken, refreshToken);
 
         response.sendRedirect("/success.html");
     }

--- a/authentication/src/main/java/kr/co/readingtown/authentication/exception/AuthenticationErrorCode.java
+++ b/authentication/src/main/java/kr/co/readingtown/authentication/exception/AuthenticationErrorCode.java
@@ -1,0 +1,17 @@
+package kr.co.readingtown.authentication.exception;
+
+import kr.co.readingtown.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AuthenticationErrorCode implements ErrorCode {
+
+    TOKEN_NOT_VALID(3001, "유효하지 않은 토큰입니다."),
+    NO_TOKEN_EXCEPTION(3002, "토큰이 없습니다"),
+    EXPIRED_TOKEN(3003, "만료된 토큰입니다.");
+
+    private final int errorCode;
+    private final String errorMessage;
+}

--- a/authentication/src/main/java/kr/co/readingtown/authentication/exception/AuthenticationException.java
+++ b/authentication/src/main/java/kr/co/readingtown/authentication/exception/AuthenticationException.java
@@ -1,0 +1,28 @@
+package kr.co.readingtown.authentication.exception;
+
+import kr.co.readingtown.common.exception.CustomException;
+
+public class AuthenticationException extends CustomException {
+
+    public AuthenticationException(final AuthenticationErrorCode authenticationErrorCode) {
+        super(authenticationErrorCode);
+    }
+
+    public static class ExpiredToken extends AuthenticationException {
+        public ExpiredToken() {
+            super(AuthenticationErrorCode.EXPIRED_TOKEN);
+        }
+    }
+
+    public static class TokenNotValid extends AuthenticationException {
+        public TokenNotValid() {
+            super(AuthenticationErrorCode.TOKEN_NOT_VALID);
+        }
+    }
+
+    public static class NoTokenException extends AuthenticationException {
+        public NoTokenException() {
+            super(AuthenticationErrorCode.NO_TOKEN_EXCEPTION);
+        }
+    }
+}

--- a/authentication/src/main/java/kr/co/readingtown/authentication/externalapi/AuthenticationController.java
+++ b/authentication/src/main/java/kr/co/readingtown/authentication/externalapi/AuthenticationController.java
@@ -1,0 +1,23 @@
+package kr.co.readingtown.authentication.externalapi;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.co.readingtown.authentication.service.AuthenticationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthenticationController {
+
+    private final AuthenticationService authenticationService;
+
+    @PostMapping("/reissue")
+    public void reissue(HttpServletRequest request, HttpServletResponse response) {
+
+        authenticationService.reissue(request, response);
+    }
+}

--- a/authentication/src/main/java/kr/co/readingtown/authentication/jwt/JwtAuthenticationEntryPoint.java
+++ b/authentication/src/main/java/kr/co/readingtown/authentication/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,43 @@
+package kr.co.readingtown.authentication.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.co.readingtown.common.exception.ErrorCode;
+import kr.co.readingtown.common.exception.httpError.HttpErrorCode;
+import kr.co.readingtown.common.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException)
+            throws IOException {
+
+        responseToClient(response, HttpErrorCode.UNAUTHORIZED);
+    }
+
+    private void responseToClient(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+
+        CommonResponse<Integer> errorResponse = new CommonResponse<>(errorCode);
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/authentication/src/main/java/kr/co/readingtown/authentication/jwt/JwtExceptionFilter.java
+++ b/authentication/src/main/java/kr/co/readingtown/authentication/jwt/JwtExceptionFilter.java
@@ -1,0 +1,47 @@
+package kr.co.readingtown.authentication.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.co.readingtown.authentication.exception.AuthenticationException;
+import kr.co.readingtown.common.exception.CustomException;
+import kr.co.readingtown.common.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        try {
+            filterChain.doFilter(request, response);
+        } catch (AuthenticationException e) {
+            responseToClient(response, e);
+        }
+    }
+
+    private void responseToClient(HttpServletResponse response, CustomException e) throws IOException {
+
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+
+        CommonResponse<Integer> errorResponse = new CommonResponse<>(e.getErrorCodeEnum());
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/authentication/src/main/java/kr/co/readingtown/authentication/jwt/TokenProvider.java
+++ b/authentication/src/main/java/kr/co/readingtown/authentication/jwt/TokenProvider.java
@@ -3,6 +3,7 @@ package kr.co.readingtown.authentication.jwt;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import kr.co.readingtown.authentication.exception.AuthenticationException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -73,10 +74,10 @@ public class TokenProvider {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
         } catch (ExpiredJwtException e) {
-            return false;
+            throw new AuthenticationException.ExpiredToken();
         }
         catch (JwtException | IllegalArgumentException e) {
-            return false;
+            throw new AuthenticationException.TokenNotValid();
         }
     }
 }

--- a/authentication/src/main/java/kr/co/readingtown/authentication/service/AuthenticationService.java
+++ b/authentication/src/main/java/kr/co/readingtown/authentication/service/AuthenticationService.java
@@ -1,0 +1,42 @@
+package kr.co.readingtown.authentication.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.co.readingtown.authentication.exception.AuthenticationException;
+import kr.co.readingtown.authentication.jwt.TokenProvider;
+import kr.co.readingtown.common.util.CookieUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthenticationService {
+
+    private final TokenProvider tokenProvider;
+    private final CookieUtil cookieUtil;
+
+    // accessToken 재발급 할 때 refreshToken도 함께 재발급
+    public void reissue(HttpServletRequest request, HttpServletResponse response) {
+
+        String refreshToken = cookieUtil.extractTokenFromCookie(request, "refresh_token");
+
+        // TODO: refreshToken 검증 로직 추가 (category 검사 + redis 확인)
+        try {
+
+            if (refreshToken != null & tokenProvider.validateToken(refreshToken)) {
+
+                String provider = tokenProvider.getProvider(refreshToken);
+                String providerId = tokenProvider.getProviderId(refreshToken);
+
+                String newAccessToken = tokenProvider.createAccessToken(provider, providerId);
+                String newRefreshToken = tokenProvider.createRefreshToken(provider, providerId);
+
+                cookieUtil.saveTokenToCookie(response, newAccessToken, newRefreshToken);
+            }
+        } catch (AuthenticationException e) {
+            throw e;
+        }
+    }
+}

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -22,4 +22,6 @@ dependencies {
 
     // openfeign
     api 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    implementation 'jakarta.servlet:jakarta.servlet-api:6.0.0'
 }

--- a/common/src/main/java/kr/co/readingtown/common/exception/CustomException.java
+++ b/common/src/main/java/kr/co/readingtown/common/exception/CustomException.java
@@ -5,10 +5,13 @@ import lombok.Getter;
 @Getter
 public class CustomException extends RuntimeException {
 
+    private final ErrorCode errorCodeEnum;
+
     private final int errorCode;
     private final String errorMessage;
 
     public <T extends Enum<T> & ErrorCode> CustomException(final T errorType) {
+        errorCodeEnum = errorType;
         errorCode = errorType.getErrorCode();
         errorMessage = errorType.getErrorMessage();
     }

--- a/common/src/main/java/kr/co/readingtown/common/exception/httpError/HttpErrorCode.java
+++ b/common/src/main/java/kr/co/readingtown/common/exception/httpError/HttpErrorCode.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum HttpErrorCode implements ErrorCode {
 
-    INTERNAL_SERVER_ERROR(2001, "요청 처리 중 알 수 없는 오류가 발생했습니다.");
+    INTERNAL_SERVER_ERROR(2001, "요청 처리 중 알 수 없는 오류가 발생했습니다."),
+    UNAUTHORIZED(2002, "인증이 필요한 요청입니다.");
 
     private final int errorCode;
     private final String errorMessage;

--- a/common/src/main/java/kr/co/readingtown/common/util/CookieUtil.java
+++ b/common/src/main/java/kr/co/readingtown/common/util/CookieUtil.java
@@ -1,0 +1,43 @@
+package kr.co.readingtown.common.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Component
+public class CookieUtil {
+
+    // type : access_token, refresh_token
+    public String extractTokenFromCookie(HttpServletRequest request, String type) {
+        if (request.getCookies() == null) return null;
+
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals(type))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    public void saveTokenToCookie(HttpServletResponse response, String accessToken, String refreshToken) {
+
+        // accessToken 쿠키 설정
+        Cookie accessTokenCookie = new Cookie("access_token", accessToken);
+        // accessTokenCookie.setHttpOnly(true);
+        // accessTokenCookie.setSecure(true);
+        accessTokenCookie.setPath("/");
+        accessTokenCookie.setMaxAge(15 * 60);
+
+        // refreshToken 쿠키 설정
+        Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken);
+        // refreshTokenCookie.setHttpOnly(true);
+        // refreshTokenCookie.setSecure(true);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge(7 * 24 * 60 * 60);
+
+        response.addCookie(accessTokenCookie);
+        response.addCookie(refreshTokenCookie);
+    }
+}


### PR DESCRIPTION
## ✨ Issue Number
> close #18 

## 📄 작업 내용 (주요 변경 사항)

- 시큐리티에서 발생하는 에러 처리하는 filter들 추가했습니다 (JwtExceptionFilter, JwtAuthenticationEntryPoint)
- 토큰 재발급 api 추가 (authentication 모듈)
- CookieUtil 추가 (common 모듈 -> 나중에 쿠키에 저장할 정보 생길까봐 common에 두었습니다)

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
