### PR TITLE
Feat: 온보딩 api 개발 및 Member, Book 엔티티 필드 수정

### DIFF
--- a/api/src/main/resources/application-local.yml
+++ b/api/src/main/resources/application-local.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:

--- a/api/src/main/resources/application-s3.yml
+++ b/api/src/main/resources/application-s3.yml
@@ -1,0 +1,7 @@
+spring:
+  config:
+    activate:
+      on-profile: s3
+app:
+  profile:
+    default-image-url: ${DEFAULT_PROFILE_URL}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -2,8 +2,8 @@ spring:
   profiles:
     active: local
     group:
-      local: local, datasource, auth
-      prod: prod, datasource, auth
+      local: local, datasource, auth, s3
+      prod: prod, datasource, auth, s3
   config:
     import: optional:file:.env[.properties]
 
@@ -16,7 +16,3 @@ server:
 
 cors:
   allowed-origins: http://localhost:3000
-
-app:
-  profile:
-    default-image-url: ${DEFAULT_PROFILE_URL}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -16,3 +16,7 @@ server:
 
 cors:
   allowed-origins: http://localhost:3000
+
+app:
+  profile:
+    default-image-url: ${DEFAULT_PROFILE_URL}

--- a/book/src/main/java/kr/co/readingtown/book/domain/Book.java
+++ b/book/src/main/java/kr/co/readingtown/book/domain/Book.java
@@ -30,12 +30,30 @@ public class Book extends BaseEntity {
 
     private String publisher;
 
+    @Column(name = "isbn", unique = true)
+    private String isbn;
+
+    @Lob
+    @Column(name = "keyword")
+    private String keyword;
+
+    @Lob
+    private String review;
+
+    @Column(name = "source_field")
+    @Enumerated(EnumType.STRING)
+    private SourceFieldType sourceField;
+
     @Builder
-    public Book(String bookName, String bookImage, String author, String summary, String publisher) {
+    public Book(String bookName, String bookImage, String author, String summary, String publisher, String isbn, String keyword, String review, SourceFieldType sourceField) {
         this.bookName = bookName;
         this.bookImage = bookImage;
         this.author = author;
         this.summary = summary;
         this.publisher = publisher;
+        this.isbn = isbn;
+        this.keyword = keyword;
+        this.review = review;
+        this.sourceField = sourceField;
     }
 }

--- a/book/src/main/java/kr/co/readingtown/book/domain/SourceFieldType.java
+++ b/book/src/main/java/kr/co/readingtown/book/domain/SourceFieldType.java
@@ -1,0 +1,6 @@
+package kr.co.readingtown.book.domain;
+
+public enum SourceFieldType {
+    CRAWLING,
+    MANUAL
+}

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     api 'mysql:mysql-connector-java:8.0.33'
 
     // security
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
+	api 'org.springframework.boot:spring-boot-starter-security'
 //	testImplementation 'org.springframework.security:spring-security-test'
 
     // openfeign

--- a/common/src/main/java/kr/co/readingtown/common/config/AppProperties.java
+++ b/common/src/main/java/kr/co/readingtown/common/config/AppProperties.java
@@ -1,0 +1,15 @@
+package kr.co.readingtown.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AppProperties {
+
+    @Value("${app.profile.default-image-url}")
+    private String defaultProfileImageUrl;
+
+    public String getDefaultProfileImageUrl() {
+        return defaultProfileImageUrl;
+    }
+}

--- a/member/build.gradle
+++ b/member/build.gradle
@@ -1,12 +1,4 @@
 
 dependencies {
     implementation project(':common')
-//
-//    // 테스트를 위해 추가된 의존성
-//    // Spring Web - RestController 사용을 위해 필요
-//    implementation 'org.springframework.boot:spring-boot-starter-web'
-//
-//    // 테스트 의존성
-//    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-//    testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/member/build.gradle
+++ b/member/build.gradle
@@ -1,4 +1,12 @@
 
 dependencies {
     implementation project(':common')
+//
+//    // 테스트를 위해 추가된 의존성
+//    // Spring Web - RestController 사용을 위해 필요
+//    implementation 'org.springframework.boot:spring-boot-starter-web'
+//
+//    // 테스트 의존성
+//    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+//    testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/member/src/main/java/kr/co/readingtown/member/domain/Member.java
+++ b/member/src/main/java/kr/co/readingtown/member/domain/Member.java
@@ -46,8 +46,11 @@ public class Member extends BaseEntity {
     @Column(name = "chat_avg_response_minutes")
     private Integer chatAvgResponseMinutes;
 
+    @Column(name = "available_time")
+    private String availableTime;
+
     @Builder
-    public Member(String username, LoginType loginType, String loginId, String profileImage, String phoneNumber, Double userRating, Integer userRatingCount, String currentTown, Double chatResponseRate, Integer chatAvgResponseMinutes) {
+    public Member(String username, LoginType loginType, String loginId, String profileImage, String phoneNumber, Double userRating, Integer userRatingCount, String currentTown, Double chatResponseRate, Integer chatAvgResponseMinutes, String availableTime) {
         this.username = username;
         this.loginType = loginType;
         this.loginId = loginId;
@@ -58,5 +61,14 @@ public class Member extends BaseEntity {
         this.currentTown = currentTown;
         this.chatResponseRate = chatResponseRate;
         this.chatAvgResponseMinutes = chatAvgResponseMinutes;
+        this.availableTime = availableTime;
+    }
+
+    public void completeOnboarding(String phoneNumber, String currentTown, String username, String profileImage, String availableTime) {
+        this.phoneNumber = phoneNumber;
+        this.currentTown = currentTown;
+        this.username = username;
+        this.profileImage = profileImage;
+        this.availableTime = availableTime;
     }
 }

--- a/member/src/main/java/kr/co/readingtown/member/dto/DefaultProfileResponseDto.java
+++ b/member/src/main/java/kr/co/readingtown/member/dto/DefaultProfileResponseDto.java
@@ -1,0 +1,5 @@
+package kr.co.readingtown.member.dto;
+
+public record DefaultProfileResponseDto(
+        String defaultUsername, String defaultProfileImage
+) {}

--- a/member/src/main/java/kr/co/readingtown/member/dto/OnboardingRequestDto.java
+++ b/member/src/main/java/kr/co/readingtown/member/dto/OnboardingRequestDto.java
@@ -1,0 +1,12 @@
+package kr.co.readingtown.member.dto;
+
+import lombok.Data;
+
+@Data
+public class OnboardingRequestDto {
+    private String phoneNumber;
+    private String currentTown;
+    private String username;
+    private String profileImage;
+    private String availableTime;
+}

--- a/member/src/main/java/kr/co/readingtown/member/exception/MemberErrorCode.java
+++ b/member/src/main/java/kr/co/readingtown/member/exception/MemberErrorCode.java
@@ -1,0 +1,16 @@
+package kr.co.readingtown.member.exception;
+
+import kr.co.readingtown.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MemberErrorCode implements ErrorCode {
+
+    MISSING_REQUIRED_FIELD(4001,"온보딩 필수 입력값이 누락되었습니다." ),
+    NO_AUTH_MEMBER(3104, "로그인된 회원 정보가 없습니다.");
+
+    private final int errorCode;
+    private final String errorMessage;
+};

--- a/member/src/main/java/kr/co/readingtown/member/exception/MemberErrorCode.java
+++ b/member/src/main/java/kr/co/readingtown/member/exception/MemberErrorCode.java
@@ -9,8 +9,12 @@ import lombok.Getter;
 public enum MemberErrorCode implements ErrorCode {
 
     MISSING_REQUIRED_FIELD(4001,"온보딩 필수 입력값이 누락되었습니다." ),
-    NO_AUTH_MEMBER(3104, "로그인된 회원 정보가 없습니다.");
+    NO_AUTH_MEMBER(4002, "로그인된 회원 정보가 없습니다."),
 
+    //닉네임 관련
+    USERNAME_GENERATION_FAILED(4010, "중복이 많아 기본 닉네임 생성에 실패했습니다."),
+    INVALID_USERNAME_FORMAT(4011, "닉네임은 2자 이상 20자 이하로 입력해주세요."),
+    USERNAME_ALREADY_EXISTS(4012, "이미 사용 중인 닉네임입니다.");
     private final int errorCode;
     private final String errorMessage;
 };

--- a/member/src/main/java/kr/co/readingtown/member/exception/MemberException.java
+++ b/member/src/main/java/kr/co/readingtown/member/exception/MemberException.java
@@ -16,4 +16,22 @@ public class MemberException extends CustomException {
             super(MemberErrorCode.NO_AUTH_MEMBER);
         }
     }
+
+    public static class UsernameGenerationFailed extends MemberException {
+        public UsernameGenerationFailed() {
+            super(MemberErrorCode.USERNAME_GENERATION_FAILED);
+        }
+    }
+
+    public static class InvalidUsername extends MemberException {
+        public InvalidUsername() {
+            super(MemberErrorCode.INVALID_USERNAME_FORMAT);
+        }
+    }
+
+    public static class UsernameAlreadyExists extends MemberException {
+        public UsernameAlreadyExists() {
+            super(MemberErrorCode.USERNAME_ALREADY_EXISTS);
+        }
+    }
 }

--- a/member/src/main/java/kr/co/readingtown/member/exception/MemberException.java
+++ b/member/src/main/java/kr/co/readingtown/member/exception/MemberException.java
@@ -1,0 +1,19 @@
+package kr.co.readingtown.member.exception;
+
+import kr.co.readingtown.common.exception.CustomException;
+
+public class MemberException extends CustomException {
+    public MemberException(final MemberErrorCode memberErrorCode) {
+        super(memberErrorCode);
+    }
+    public static class MissingRequiredField extends MemberException {
+        public MissingRequiredField() {
+            super(MemberErrorCode.MISSING_REQUIRED_FIELD);
+        }
+    }
+    public static class NoAuthMember extends MemberException {
+        public NoAuthMember() {
+            super(MemberErrorCode.NO_AUTH_MEMBER);
+        }
+    }
+}

--- a/member/src/main/java/kr/co/readingtown/member/externalapi/ExternalMemberController.java
+++ b/member/src/main/java/kr/co/readingtown/member/externalapi/ExternalMemberController.java
@@ -18,6 +18,7 @@ public class ExternalMemberController {
 
     @GetMapping("/onboarding/default-profile")
     public DefaultProfileResponseDto getDefaultProfile(@AuthenticationPrincipal Long memberId) {
+
         return memberService.getDefaultProfile(memberId);
     }
 
@@ -25,18 +26,12 @@ public class ExternalMemberController {
     public void completeOnboarding(@AuthenticationPrincipal Long memberId,
                                    @RequestBody OnboardingRequestDto onboardingRequestDto) {
 
-        memberService.completeOnboarding(
-                memberId,
-                onboardingRequestDto.getPhoneNumber(),
-                onboardingRequestDto.getCurrentTown(),
-                onboardingRequestDto.getUsername(),
-                onboardingRequestDto.getProfileImage(),
-                onboardingRequestDto.getAvailableTime()
-        );
+        memberService.completeOnboarding(memberId, onboardingRequestDto);
     }
 
     @GetMapping("/username/check")
     public Map<String, Boolean> checkUsername(@RequestParam String username) {
+
         boolean available = memberService.isUsernameAvailable(username);
         return Map.of("isAvailable", available);
     }

--- a/member/src/main/java/kr/co/readingtown/member/externalapi/ExternalMemberController.java
+++ b/member/src/main/java/kr/co/readingtown/member/externalapi/ExternalMemberController.java
@@ -1,10 +1,13 @@
 package kr.co.readingtown.member.externalapi;
 
+import kr.co.readingtown.member.dto.DefaultProfileResponseDto;
 import kr.co.readingtown.member.dto.OnboardingRequestDto;
 import kr.co.readingtown.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api")
@@ -13,8 +16,13 @@ public class ExternalMemberController {
 
     private final MemberService memberService;
 
+    @GetMapping("/v1/onboarding/default-profile")
+    public DefaultProfileResponseDto getDefaultProfile(@AuthenticationPrincipal Long memberId) {
+        return memberService.getDefaultProfile(memberId);
+    }
+
     @PostMapping("/v1/onboarding/complete")
-    public Void completeOnboarding(@AuthenticationPrincipal Long memberId,
+    public void completeOnboarding(@AuthenticationPrincipal Long memberId,
                                    @RequestBody OnboardingRequestDto onboardingRequestDto) {
 
         memberService.completeOnboarding(
@@ -25,6 +33,11 @@ public class ExternalMemberController {
                 onboardingRequestDto.getProfileImage(),
                 onboardingRequestDto.getAvailableTime()
         );
-        return null;
+    }
+
+    @GetMapping("/v1/members/username/check")
+    public Map<String, Boolean> checkUsername(@RequestParam String username) {
+        boolean available = memberService.isUsernameAvailable(username);
+        return Map.of("isAvailable", available);
     }
 }

--- a/member/src/main/java/kr/co/readingtown/member/externalapi/ExternalMemberController.java
+++ b/member/src/main/java/kr/co/readingtown/member/externalapi/ExternalMemberController.java
@@ -10,18 +10,18 @@ import org.springframework.web.bind.annotation.*;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/v1/members")
 @RequiredArgsConstructor
 public class ExternalMemberController {
 
     private final MemberService memberService;
 
-    @GetMapping("/v1/onboarding/default-profile")
+    @GetMapping("/onboarding/default-profile")
     public DefaultProfileResponseDto getDefaultProfile(@AuthenticationPrincipal Long memberId) {
         return memberService.getDefaultProfile(memberId);
     }
 
-    @PostMapping("/v1/onboarding/complete")
+    @PostMapping("/onboarding/complete")
     public void completeOnboarding(@AuthenticationPrincipal Long memberId,
                                    @RequestBody OnboardingRequestDto onboardingRequestDto) {
 
@@ -35,7 +35,7 @@ public class ExternalMemberController {
         );
     }
 
-    @GetMapping("/v1/members/username/check")
+    @GetMapping("/username/check")
     public Map<String, Boolean> checkUsername(@RequestParam String username) {
         boolean available = memberService.isUsernameAvailable(username);
         return Map.of("isAvailable", available);

--- a/member/src/main/java/kr/co/readingtown/member/externalapi/ExternalMemberController.java
+++ b/member/src/main/java/kr/co/readingtown/member/externalapi/ExternalMemberController.java
@@ -1,0 +1,30 @@
+package kr.co.readingtown.member.externalapi;
+
+import kr.co.readingtown.member.dto.OnboardingRequestDto;
+import kr.co.readingtown.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ExternalMemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/v1/onboarding/complete")
+    public Void completeOnboarding(@AuthenticationPrincipal Long memberId,
+                                   @RequestBody OnboardingRequestDto onboardingRequestDto) {
+
+        memberService.completeOnboarding(
+                memberId,
+                onboardingRequestDto.getPhoneNumber(),
+                onboardingRequestDto.getCurrentTown(),
+                onboardingRequestDto.getUsername(),
+                onboardingRequestDto.getProfileImage(),
+                onboardingRequestDto.getAvailableTime()
+        );
+        return null;
+    }
+}

--- a/member/src/main/java/kr/co/readingtown/member/repository/MemberRepository.java
+++ b/member/src/main/java/kr/co/readingtown/member/repository/MemberRepository.java
@@ -9,4 +9,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByLoginTypeAndLoginId(LoginType loginType, String loginId);
 
     Member findByLoginTypeAndLoginId(LoginType loginType, String loginId);
+
+    boolean existsByUsername(String candidate);
 }

--- a/member/src/main/java/kr/co/readingtown/member/service/MemberService.java
+++ b/member/src/main/java/kr/co/readingtown/member/service/MemberService.java
@@ -3,11 +3,14 @@ package kr.co.readingtown.member.service;
 import kr.co.readingtown.common.config.AppProperties;
 import kr.co.readingtown.member.domain.Member;
 import kr.co.readingtown.member.domain.enums.LoginType;
+import kr.co.readingtown.member.dto.DefaultProfileResponseDto;
 import kr.co.readingtown.member.exception.MemberException;
 import kr.co.readingtown.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -40,16 +43,65 @@ public class MemberService {
     @Transactional
     public void completeOnboarding(Long memberId, String phoneNumber, String currentTown, String username, String profileImage, String availableTime) {
 
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberException.NoAuthMember::new);
+
         if (phoneNumber == null || phoneNumber.isBlank()
-                || username == null || username.isBlank()) {
+                || currentTown == null || currentTown.isBlank()
+                || username == null || username.isBlank()
+                || profileImage == null || profileImage.isBlank()) {
             throw new MemberException.MissingRequiredField();
         }
 
-        Member member = memberRepository.findById(memberId).orElseThrow(MemberException.NoAuthMember::new);
-
-        if(profileImage == null || profileImage.isBlank()) {
-            profileImage = appProperties.getDefaultProfileImageUrl();
-        }
         member.completeOnboarding(phoneNumber, currentTown, username, profileImage, availableTime);
     }
+
+    public DefaultProfileResponseDto getDefaultProfile(Long memberId) {
+
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberException.NoAuthMember::new);
+
+        String defaultUsername = generateUniqueUsername();
+        String defaultImageUrl = appProperties.getDefaultProfileImageUrl();
+
+        return new DefaultProfileResponseDto(defaultUsername, defaultImageUrl);
+    }
+
+    //랜덤 닉네임 설정
+    private String generateUniqueUsername() {
+        String prefix = "리딩여우";
+        String candidate;
+        int attempt = 0;
+
+        //리딩여우+랜덤숫자문자 생성
+        do {
+            String random = UUID.randomUUID().toString().replace("-", "").substring(0, 6);
+            candidate = prefix + random;
+            attempt++;
+            if (attempt > 10) {
+                throw new MemberException.UsernameGenerationFailed();
+            }
+        } while (memberRepository.existsByUsername(candidate));
+
+        return candidate;
+    }
+
+    //닉네임 사용가능 여부 확인
+    public boolean isUsernameAvailable(String username) {
+        //null 체크
+        if (username == null || username.isBlank()) {
+            throw new MemberException.InvalidUsername();
+        }
+
+        // 길이 제한 체크
+        if (username.length() < 2 || username.length() > 20) {
+            throw new MemberException.InvalidUsername();
+        }
+
+        //중복체크
+        if (memberRepository.existsByUsername(username)) {
+            throw new MemberException.UsernameAlreadyExists();
+        }
+
+        return true;
+    }
+
 }

--- a/member/src/main/java/kr/co/readingtown/member/service/MemberService.java
+++ b/member/src/main/java/kr/co/readingtown/member/service/MemberService.java
@@ -4,6 +4,7 @@ import kr.co.readingtown.common.config.AppProperties;
 import kr.co.readingtown.member.domain.Member;
 import kr.co.readingtown.member.domain.enums.LoginType;
 import kr.co.readingtown.member.dto.DefaultProfileResponseDto;
+import kr.co.readingtown.member.dto.OnboardingRequestDto;
 import kr.co.readingtown.member.exception.MemberException;
 import kr.co.readingtown.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -41,18 +42,18 @@ public class MemberService {
     }
 
     @Transactional
-    public void completeOnboarding(Long memberId, String phoneNumber, String currentTown, String username, String profileImage, String availableTime) {
+    public void completeOnboarding(Long memberId, OnboardingRequestDto onboardingRequestDto) {
 
-        Member member = memberRepository.findById(memberId).orElseThrow(MemberException.NoAuthMember::new);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberException.NoAuthMember::new);
 
-        if (phoneNumber == null || phoneNumber.isBlank()
-                || currentTown == null || currentTown.isBlank()
-                || username == null || username.isBlank()
-                || profileImage == null || profileImage.isBlank()) {
-            throw new MemberException.MissingRequiredField();
-        }
-
-        member.completeOnboarding(phoneNumber, currentTown, username, profileImage, availableTime);
+        member.completeOnboarding(
+                onboardingRequestDto.getPhoneNumber(),
+                onboardingRequestDto.getCurrentTown(),
+                onboardingRequestDto.getUsername(),
+                onboardingRequestDto.getProfileImage(),
+                onboardingRequestDto.getAvailableTime()
+        );
     }
 
     public DefaultProfileResponseDto getDefaultProfile(Long memberId) {
@@ -67,6 +68,7 @@ public class MemberService {
 
     //랜덤 닉네임 설정
     private String generateUniqueUsername() {
+
         String prefix = "리딩여우";
         String candidate;
         int attempt = 0;

--- a/member/src/main/java/kr/co/readingtown/member/service/MemberService.java
+++ b/member/src/main/java/kr/co/readingtown/member/service/MemberService.java
@@ -1,7 +1,9 @@
 package kr.co.readingtown.member.service;
 
+import kr.co.readingtown.common.config.AppProperties;
 import kr.co.readingtown.member.domain.Member;
 import kr.co.readingtown.member.domain.enums.LoginType;
+import kr.co.readingtown.member.exception.MemberException;
 import kr.co.readingtown.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final AppProperties appProperties;
 
     @Transactional
     public void registerMember(LoginType loginType, String loginId, String username) {
@@ -32,5 +35,21 @@ public class MemberService {
 
         Member member = memberRepository.findByLoginTypeAndLoginId(loginType, loginId);
         return member.getMemberId();
+    }
+
+    @Transactional
+    public void completeOnboarding(Long memberId, String phoneNumber, String currentTown, String username, String profileImage, String availableTime) {
+
+        if (phoneNumber == null || phoneNumber.isBlank()
+                || username == null || username.isBlank()) {
+            throw new MemberException.MissingRequiredField();
+        }
+
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberException.NoAuthMember::new);
+
+        if(profileImage == null || profileImage.isBlank()) {
+            profileImage = appProperties.getDefaultProfileImageUrl();
+        }
+        member.completeOnboarding(phoneNumber, currentTown, username, profileImage, availableTime);
     }
 }


### PR DESCRIPTION
## ✨ Issue Number
> close #27 
> close #21 

## 📄 작업 내용 (주요 변경 사항)
1. 온보딩 관련 api 개발
  - 기본 프로필 조회 API
    - "리딩여우" + 랜덤 6자리 문자로 구성된 기본 닉네임 생성
    - S3 연동을 통한 기본 프로필 이미지 URL 제공
  - 닉네임 중복 확인 API
  - 온보딩 완료 후 유저 데이터 저장 API

2. Member 도메인 개선
  - availableTime 필드 추가
  - Member 관련 커스텀 예외 처리 (4000번대 에러 코드)

3. Book 엔티티 보완
  - 누락된 필드 추가: isbn, keyword, review, sourceField
  - SourceFieldType enum 추가 (CRAWLING, MANUAL)

## 💬 리뷰 요구사항
- default image url 환경변수 application.yml 위치에 app 아래에 뒀는데 해당 위치가 괜찮은지 궁금합니다. 따로 도메인과 관련된 yml 파일을 하나 더 만들어야할까요?!
- Book 엔티티의 review, keyword 타입 수정이 필요하면 말씀해주세요~
- 추가된 환경변수는 notion에만 적어뒀습니다.

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **신규 기능**
  * 회원 온보딩 완료 및 프로필 정보(전화번호, 거주지, 닉네임, 프로필 이미지, 이용 가능 시간) 등록 기능이 추가되었습니다.
  * 기본 프로필(기본 닉네임 및 프로필 이미지) 조회 기능이 제공됩니다.
  * 닉네임 중복 및 유효성(길이 등) 확인 기능이 추가되었습니다.
  * 책 정보에 ISBN, 키워드, 리뷰, 소스 구분 필드가 추가되었습니다.

* **버그 수정**
  * 데이터베이스 스키마 적용 방식이 개선되어, 기존 데이터가 삭제되지 않고 업데이트됩니다.

* **환경설정**
  * 기본 프로필 이미지 URL을 환경 변수로 지정할 수 있습니다.
  * S3 프로필이 환경설정에 추가되었습니다.

* **기타**
  * 회원 관련 오류 코드 및 예외 처리 체계가 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->