### PR TITLE
Fix: swagger 패키지 스캔, 에러 로그 추가

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 
 	// security
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/api/src/main/java/kr/co/readingtown/response/CustomResponseBodyAdvice.java
+++ b/api/src/main/java/kr/co/readingtown/response/CustomResponseBodyAdvice.java
@@ -38,6 +38,10 @@ public class CustomResponseBodyAdvice implements ResponseBodyAdvice<Object> {
             return body;
         }
 
+        if (path.startsWith("/v3/api-docs") || path.startsWith("/swagger-ui")) {
+            return body;
+        }
+
         return new CommonResponse<>(body);
     }
 }

--- a/api/src/main/java/kr/co/readingtown/swagger/SwaggerConfig.java
+++ b/api/src/main/java/kr/co/readingtown/swagger/SwaggerConfig.java
@@ -3,6 +3,7 @@ package kr.co.readingtown.swagger;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
+import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +15,17 @@ public class SwaggerConfig {
 
     @Value("${server.base-uri}")
     private String serverUri;
+
+    // TODO : 앞으로 외부 API 문서화가 필요한 api의 패키지를 packagesToScan에 추가해주세요!!
+    @Bean
+    public GroupedOpenApi externalApiGroup() {
+        return GroupedOpenApi.builder()
+                .group("external-api")
+                .packagesToScan(
+                        "kr.co.readingtown.member.externalapi"
+                )
+                .build();
+    }
 
     @Bean
     public OpenAPI openAPI() {

--- a/api/src/main/resources/application-local.yml
+++ b/api/src/main/resources/application-local.yml
@@ -22,3 +22,4 @@ logging:
     root: INFO
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql.BasicBinder: DEBUG
+    org.hibernate.engine.internal.StatisticalLoggingSessionEventListener: WARN

--- a/api/src/main/resources/application-prod.yml
+++ b/api/src/main/resources/application-prod.yml
@@ -15,3 +15,4 @@ logging:
   level:
     root: WARN
     org.hibernate.SQL: ERROR
+    org.hibernate.engine.internal.StatisticalLoggingSessionEventListener: OFF

--- a/common/src/main/java/kr/co/readingtown/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/kr/co/readingtown/common/exception/GlobalExceptionHandler.java
@@ -1,26 +1,138 @@
 package kr.co.readingtown.common.exception;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
 import kr.co.readingtown.common.exception.httpError.HttpErrorCode;
+import kr.co.readingtown.common.log.LogInfo;
+import kr.co.readingtown.common.log.LogLevel;
+import kr.co.readingtown.common.log.LogUtil;
 import kr.co.readingtown.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED;
 
 @Slf4j
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<CommonResponse<HttpErrorCode>> handleUnknownException(final Exception e) {
+    private final LogUtil logUtil;
 
-        log.error("[INTERNAL_SERVER_ERROR]", e);
+    // Custom 예외 발생 시
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<CommonResponse<Object>> handleBadRequestException(CustomException e, HttpServletRequest request){
+
+        logUtil.printSystemLog(LogInfo.from(e, request), LogLevel.WARN);
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new CommonResponse<>(e.getErrorCodeEnum()));
+    }
+
+    // @Valid 검증 실패 시
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<CommonResponse<Object>> methodArgumentNotValidException(MethodArgumentNotValidException e, HttpServletRequest request) {
+
+        logUtil.printSystemLog(LogInfo.from(e, request), LogLevel.WARN);
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new CommonResponse<>(HttpErrorCode.VALIDATION_FAILED));
+    }
+
+    // 허용하지 않는 HTTP 메서드 요청 시
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<CommonResponse<Object>> handleMethodNotSupported(HttpRequestMethodNotSupportedException e, HttpServletRequest request) {
+
+        logUtil.printSystemLog(LogInfo.from(e, request), LogLevel.WARN);
+
+        return ResponseEntity
+                .status(METHOD_NOT_ALLOWED)
+                .body(new CommonResponse<>(HttpErrorCode.METHOD_NOT_ALLOWED));
+    }
+
+    // 필수 요청 파라미터 누락 시
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<CommonResponse<Object>> handleMissingParam(MissingServletRequestParameterException e, HttpServletRequest request) {
+
+        logUtil.printSystemLog(LogInfo.from(e, request), LogLevel.WARN);
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new CommonResponse<>(HttpErrorCode.MISSING_PARAMETER));
+    }
+
+    // 요청 바디가 JSON 등으로 파싱 실패 시
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<CommonResponse<Object>> handleMessageNotReadable(HttpMessageNotReadableException e, HttpServletRequest request) {
+
+        logUtil.printSystemLog(LogInfo.from(e, request), LogLevel.WARN);
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new CommonResponse<>(HttpErrorCode.MESSAGE_NOT_READABLE));
+    }
+
+    // 파라미터 유효성 제약 조건 위반 시
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<CommonResponse<Object>> handleConstraintViolation(ConstraintViolationException e, HttpServletRequest request) {
+
+        logUtil.printSystemLog(LogInfo.from(e, request), LogLevel.WARN);
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new CommonResponse<>(HttpErrorCode.CONSTRAINT_VIOLATION));
+    }
+
+    // 권한이 없는 요청 시
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<CommonResponse<Object>> handleAccessDenied(AccessDeniedException e, HttpServletRequest request) {
+
+        logUtil.printSystemLog(LogInfo.from(e, request), LogLevel.WARN);
+
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(new CommonResponse<>(HttpErrorCode.UNAUTHORIZED));
+    }
+
+    // DB 제약조건 위반 등 충돌 시
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<CommonResponse<Object>> handleDataIntegrityViolation(DataIntegrityViolationException e, HttpServletRequest request) {
+
+        logUtil.printSystemLog(LogInfo.from(e, request), LogLevel.ERROR);
+
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(new CommonResponse<>(HttpErrorCode.DATA_CONFLICT));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CommonResponse<HttpErrorCode>> handleUnknownException(final Exception e, HttpServletRequest request) {
+
+        // no static resoure
+        if (e.getClass().getName().equals("org.springframework.web.servlet.resource.NoResourceFoundException")) {
+
+            logUtil.printSystemLog(LogInfo.from(e, request), LogLevel.WARN);
+
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new CommonResponse<>(HttpErrorCode.NOT_FOUND));
+        }
+
+        logUtil.printSystemLog(LogInfo.from(e, request), LogLevel.ERROR);
 
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new CommonResponse<>(HttpErrorCode.INTERNAL_SERVER_ERROR));
+                .body(new CommonResponse<>(e));
     }
 }

--- a/common/src/main/java/kr/co/readingtown/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/kr/co/readingtown/common/exception/GlobalExceptionHandler.java
@@ -103,7 +103,7 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity
                 .status(HttpStatus.FORBIDDEN)
-                .body(new CommonResponse<>(HttpErrorCode.UNAUTHORIZED));
+                .body(new CommonResponse<>(HttpErrorCode.ACCESS_DENIED));
     }
 
     // DB 제약조건 위반 등 충돌 시
@@ -118,7 +118,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<CommonResponse<HttpErrorCode>> handleUnknownException(final Exception e, HttpServletRequest request) {
+    public ResponseEntity<CommonResponse<Object>> handleUnknownException(final Exception e, HttpServletRequest request) {
 
         // no static resoure
         if (e.getClass().getName().equals("org.springframework.web.servlet.resource.NoResourceFoundException")) {

--- a/common/src/main/java/kr/co/readingtown/common/exception/httpError/HttpErrorCode.java
+++ b/common/src/main/java/kr/co/readingtown/common/exception/httpError/HttpErrorCode.java
@@ -9,7 +9,16 @@ import lombok.Getter;
 public enum HttpErrorCode implements ErrorCode {
 
     INTERNAL_SERVER_ERROR(2001, "요청 처리 중 알 수 없는 오류가 발생했습니다."),
-    UNAUTHORIZED(2002, "인증이 필요한 요청입니다.");
+    UNAUTHORIZED(2002, "인증이 필요한 요청입니다."),
+    BAD_REQUEST(2003, "잘못된 요청입니다."),
+    METHOD_NOT_ALLOWED(2004, "허용되지 않는 HTTP 메서드입니다."),
+    VALIDATION_FAILED(2005, "입력값 검증에 실패했습니다."),
+    MISSING_PARAMETER(2006, "필수 요청 파라미터가 누락되었습니다."),
+    MESSAGE_NOT_READABLE(2007, "요청 메시지를 읽을 수 없습니다."),
+    CONSTRAINT_VIOLATION(2008, "유효성 제약 조건 위반입니다."),
+    ACCESS_DENIED(2009, "접근 권한이 없습니다."),
+    NOT_FOUND(2010, "요청하신 자원을 찾을 수 없습니다."),
+    DATA_CONFLICT(2011, "데이터 충돌이 발생했습니다.");
 
     private final int errorCode;
     private final String errorMessage;

--- a/common/src/main/java/kr/co/readingtown/common/log/LogInfo.java
+++ b/common/src/main/java/kr/co/readingtown/common/log/LogInfo.java
@@ -1,0 +1,37 @@
+package kr.co.readingtown.common.log;
+
+import jakarta.servlet.http.HttpServletRequest;
+import kr.co.readingtown.common.exception.CustomException;
+
+import java.util.Arrays;
+
+public record LogInfo(
+        String method,
+        String uri,
+        String message,
+        String location
+) {
+
+    public static LogInfo from(Exception e, HttpServletRequest request) {
+
+        // 오류 메시지
+        String formatMessage;
+        if (e instanceof CustomException ce)
+            formatMessage = ce.getErrorMessage();
+        else
+            formatMessage = e.getMessage();
+
+        // 오류 발생 위치
+        String formatLocation = Arrays.stream(e.getStackTrace())
+                .findFirst()
+                .map(StackTraceElement::toString)
+                .orElse("no stack");
+
+        return new LogInfo(
+                request.getMethod(),
+                request.getRequestURI(),
+                formatMessage,
+                formatLocation
+        );
+    }
+}

--- a/common/src/main/java/kr/co/readingtown/common/log/LogLevel.java
+++ b/common/src/main/java/kr/co/readingtown/common/log/LogLevel.java
@@ -1,0 +1,5 @@
+package kr.co.readingtown.common.log;
+
+public enum LogLevel {
+    TRACE, DEBUG, INFO, WARN, ERROR
+}

--- a/common/src/main/java/kr/co/readingtown/common/log/LogUtil.java
+++ b/common/src/main/java/kr/co/readingtown/common/log/LogUtil.java
@@ -1,0 +1,39 @@
+package kr.co.readingtown.common.log;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class LogUtil {
+
+    public void printSystemLog(LogInfo info, LogLevel level) {
+
+        StringBuilder sb = new StringBuilder();
+
+        // 1. 요청 메서드 타입
+        sb.append("METHOD=").append(info.method()).append(" | ");
+
+        // 2.요청 URI
+        sb.append("REQUEST_URI=").append(info.uri()).append(" | ");
+
+        // 3. 오류 메시지
+        sb.append("MESSAGE=").append(info.message()).append(" | ");
+
+        // 4. 오류 발생 위치
+        sb.append("LOCATION=").append(info.location());
+
+        // 5. 로그 출력
+        print(level, sb.toString());
+    }
+
+    private void print(final LogLevel level, final String logDetail) {
+        switch (level) {
+            case TRACE -> log.trace(logDetail);
+            case DEBUG -> log.debug(logDetail);
+            case WARN -> log.warn(logDetail);
+            case ERROR -> log.error(logDetail);
+            default -> log.info(logDetail);
+        }
+    }
+}

--- a/common/src/main/java/kr/co/readingtown/common/response/CommonResponse.java
+++ b/common/src/main/java/kr/co/readingtown/common/response/CommonResponse.java
@@ -2,6 +2,7 @@ package kr.co.readingtown.common.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import kr.co.readingtown.common.exception.ErrorCode;
+import kr.co.readingtown.common.exception.httpError.HttpErrorCode;
 
 import java.time.LocalDateTime;
 
@@ -18,8 +19,13 @@ public record CommonResponse<T>(
         this(LocalDateTime.now(), 1000, "Success", result);
     }
 
-    // api 응답이 실패인 경우
+    // 비즈니스 로직에서 정의한 커스텀 예외(ErrorCode) 발생 시 실패 응답 생성
     public CommonResponse(ErrorCode errorCode) {
         this(LocalDateTime.now(), errorCode.getErrorCode(), errorCode.getErrorMessage(), null);
+    }
+
+    // 시스템 또는 외부 예외(Exception) 발생 시 실패 응답 생성
+    public CommonResponse(Exception e) {
+        this(LocalDateTime.now(), 2001, e.getMessage(), null);
     }
 }


### PR DESCRIPTION
## ✨ Issue Number
> close #34 

## 📄 작업 내용 (주요 변경 사항)

- swagger config에 스캔 대상이 되는 패키지 추가 (external만 보이게 하기 위해서!)
- GlobalExceptionHandler에 exception 들 추가 + 로그 util 추가 (로그 포맷)
- 외부 exception의 에러 메시지를 반환하기 위해 외부 exception용 CommonResponse 추가

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 외부 API 그룹을 위한 별도 Swagger 문서 그룹이 추가되었습니다.
  * 다양한 예외 상황에 대해 세분화된 예외 처리와 상세한 에러 메시지 및 코드가 도입되었습니다.
  * 로그 유틸리티 및 로그 레벨 관리 기능이 추가되어 에러 발생 시 상세 로그가 기록됩니다.

* **버그 수정**
  * Swagger 관련 경로(/v3/api-docs, /swagger-ui) 응답이 불필요하게 래핑되지 않도록 개선되었습니다.

* **환경설정**
  * 로컬 및 운영 환경에서 Hibernate 관련 로깅 레벨이 조정되었습니다.

* **기타**
  * 공통 응답 객체에 Exception 기반 생성자가 추가되어 예외 응답 처리 범위가 넓어졌습니다.
  * HTTP 에러 코드가 다양하게 추가되어 에러 응답의 식별성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->