### PR TITLE
Feat: Book API 

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
 	// security
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/api/src/main/java/kr/co/readingtown/config/SecurityWebConfig.java
+++ b/api/src/main/java/kr/co/readingtown/config/SecurityWebConfig.java
@@ -38,7 +38,10 @@ public class SecurityWebConfig {
 
     private final String[] PermitAllPatterns = {
             "/",
-            "/login**"
+            "/login**",
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html"
     };
 
     @Bean

--- a/api/src/main/java/kr/co/readingtown/swagger/SwaggerConfig.java
+++ b/api/src/main/java/kr/co/readingtown/swagger/SwaggerConfig.java
@@ -23,7 +23,8 @@ public class SwaggerConfig {
                 .group("external-api")
                 .packagesToScan(
                         "kr.co.readingtown.member.externalapi",
-                        "kr.co.readingtown.review.externalapi"
+                        "kr.co.readingtown.review.externalapi",
+                        "kr.co.readingtown.book.externalapi"
                 )
                 .build();
     }

--- a/api/src/main/java/kr/co/readingtown/swagger/SwaggerConfig.java
+++ b/api/src/main/java/kr/co/readingtown/swagger/SwaggerConfig.java
@@ -22,7 +22,8 @@ public class SwaggerConfig {
         return GroupedOpenApi.builder()
                 .group("external-api")
                 .packagesToScan(
-                        "kr.co.readingtown.member.externalapi"
+                        "kr.co.readingtown.member.externalapi",
+                        "kr.co.readingtown.review.externalapi"
                 )
                 .build();
     }

--- a/book/src/main/java/kr/co/readingtown/book/dto/query/BookInfoDto.java
+++ b/book/src/main/java/kr/co/readingtown/book/dto/query/BookInfoDto.java
@@ -1,0 +1,10 @@
+package kr.co.readingtown.book.dto.query;
+
+public record BookInfoDto(
+        String bookName,
+        String bookImage,
+        String author,
+        String publisher,
+        String summary
+) {
+}

--- a/book/src/main/java/kr/co/readingtown/book/dto/response/BookResponseDto.java
+++ b/book/src/main/java/kr/co/readingtown/book/dto/response/BookResponseDto.java
@@ -1,0 +1,23 @@
+package kr.co.readingtown.book.dto.response;
+
+import kr.co.readingtown.book.dto.query.BookInfoDto;
+
+public record BookResponseDto(
+        String bookName,
+        String bookImage,
+        String author,
+        String publisher,
+        String summary
+) {
+
+    public static BookResponseDto toBookResponseDto(BookInfoDto dto) {
+
+        return new BookResponseDto(
+                dto.bookName(),
+                dto.bookImage(),
+                dto.author(),
+                dto.publisher(),
+                dto.summary()
+        );
+    }
+}

--- a/book/src/main/java/kr/co/readingtown/book/exception/BookErrorCode.java
+++ b/book/src/main/java/kr/co/readingtown/book/exception/BookErrorCode.java
@@ -1,0 +1,15 @@
+package kr.co.readingtown.book.exception;
+
+import kr.co.readingtown.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum BookErrorCode implements ErrorCode {
+
+    BOOK_NOT_FOUND(6001, "해당 책은 존재하지 않습니다.");
+
+    private final int errorCode;
+    private final String errorMessage;
+}

--- a/book/src/main/java/kr/co/readingtown/book/exception/BookException.java
+++ b/book/src/main/java/kr/co/readingtown/book/exception/BookException.java
@@ -1,0 +1,16 @@
+package kr.co.readingtown.book.exception;
+
+import kr.co.readingtown.common.exception.CustomException;
+
+public class BookException extends CustomException {
+
+    public BookException(final BookErrorCode bookErrorCode) {
+        super(bookErrorCode);
+    }
+
+    public static class BookNotFound extends BookException {
+        public BookNotFound() {
+            super(BookErrorCode.BOOK_NOT_FOUND);
+        }
+    }
+}

--- a/book/src/main/java/kr/co/readingtown/book/externalapi/ExternalBookController.java
+++ b/book/src/main/java/kr/co/readingtown/book/externalapi/ExternalBookController.java
@@ -1,0 +1,23 @@
+package kr.co.readingtown.book.externalapi;
+
+import kr.co.readingtown.book.dto.response.BookResponseDto;
+import kr.co.readingtown.book.service.BookService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/books")
+public class ExternalBookController {
+
+    private final BookService bookService;
+
+    @GetMapping("/{bookId}")
+    public BookResponseDto getBookInfo(@PathVariable("bookId") Long bookId) {
+
+        return bookService.getBookInfo(bookId);
+    }
+}

--- a/book/src/main/java/kr/co/readingtown/book/internalapi/InternalBookController.java
+++ b/book/src/main/java/kr/co/readingtown/book/internalapi/InternalBookController.java
@@ -1,0 +1,22 @@
+package kr.co.readingtown.book.internalapi;
+
+import kr.co.readingtown.book.service.BookService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/books")
+public class InternalBookController {
+
+    private final BookService bookService;
+
+    @GetMapping("/{bookId}/exists")
+    public boolean existsBook(@PathVariable("bookId") Long bookId) {
+
+        return bookService.getBookExists(bookId);
+    }
+}

--- a/book/src/main/java/kr/co/readingtown/book/repository/BookRepository.java
+++ b/book/src/main/java/kr/co/readingtown/book/repository/BookRepository.java
@@ -1,0 +1,7 @@
+package kr.co.readingtown.book.repository;
+
+import kr.co.readingtown.book.domain.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookRepository extends JpaRepository<Book, Long> {
+}

--- a/book/src/main/java/kr/co/readingtown/book/repository/BookRepository.java
+++ b/book/src/main/java/kr/co/readingtown/book/repository/BookRepository.java
@@ -1,7 +1,25 @@
 package kr.co.readingtown.book.repository;
 
 import kr.co.readingtown.book.domain.Book;
+import kr.co.readingtown.book.dto.query.BookInfoDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
+
+    @Query("""
+    SELECT new kr.co.readingtown.book.dto.query.BookInfoDto(
+        b.bookName,
+        b.bookImage,
+        b.author,
+        b.publisher,
+        b.summary
+    )
+    FROM Book b
+    WHERE b.bookId = :bookId
+    """)
+    Optional<BookInfoDto> findBookInfoById(@Param("bookId") Long bookId);
 }

--- a/book/src/main/java/kr/co/readingtown/book/service/BookService.java
+++ b/book/src/main/java/kr/co/readingtown/book/service/BookService.java
@@ -17,6 +17,8 @@ public class BookService {
 
     public boolean getBookExists(Long bookId) {
 
+        if (bookId == null)
+            return (false);
         return bookRepository.existsById(bookId);
     }
 

--- a/book/src/main/java/kr/co/readingtown/book/service/BookService.java
+++ b/book/src/main/java/kr/co/readingtown/book/service/BookService.java
@@ -1,0 +1,19 @@
+package kr.co.readingtown.book.service;
+
+import kr.co.readingtown.book.repository.BookRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BookService {
+
+    private final BookRepository bookRepository;
+
+    public boolean getBookExists(Long bookId) {
+
+        return bookRepository.existsById(bookId);
+    }
+}

--- a/book/src/main/java/kr/co/readingtown/book/service/BookService.java
+++ b/book/src/main/java/kr/co/readingtown/book/service/BookService.java
@@ -1,5 +1,8 @@
 package kr.co.readingtown.book.service;
 
+import kr.co.readingtown.book.dto.query.BookInfoDto;
+import kr.co.readingtown.book.dto.response.BookResponseDto;
+import kr.co.readingtown.book.exception.BookException;
 import kr.co.readingtown.book.repository.BookRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,5 +18,14 @@ public class BookService {
     public boolean getBookExists(Long bookId) {
 
         return bookRepository.existsById(bookId);
+    }
+
+    // 책 기본 정보 조회
+    public BookResponseDto getBookInfo(Long bookId) {
+
+        BookInfoDto bookInfoDto = bookRepository.findBookInfoById(bookId)
+                .orElseThrow(BookException.BookNotFound::new);
+
+        return BookResponseDto.toBookResponseDto(bookInfoDto);
     }
 }

--- a/member/src/main/java/kr/co/readingtown/member/dto/query/MemberIdNameDto.java
+++ b/member/src/main/java/kr/co/readingtown/member/dto/query/MemberIdNameDto.java
@@ -1,0 +1,7 @@
+package kr.co.readingtown.member.dto.query;
+
+public record MemberIdNameDto(
+        Long id,
+        String name
+) {
+}

--- a/member/src/main/java/kr/co/readingtown/member/internalapi/InternalMemberController.java
+++ b/member/src/main/java/kr/co/readingtown/member/internalapi/InternalMemberController.java
@@ -37,4 +37,10 @@ public class InternalMemberController {
 
         return memberService.getMembersName(memberIds);
     }
+
+    @GetMapping("/{memberId}/exists")
+    public boolean existsMember(@PathVariable("memberId") Long memberId) {
+
+        return memberService.getMemberExists(memberId);
+    }
 }

--- a/member/src/main/java/kr/co/readingtown/member/internalapi/InternalMemberController.java
+++ b/member/src/main/java/kr/co/readingtown/member/internalapi/InternalMemberController.java
@@ -5,6 +5,9 @@ import kr.co.readingtown.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+import java.util.Map;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/internal/members")
@@ -27,5 +30,11 @@ public class InternalMemberController {
             @RequestParam("providerId") String loginId) {
 
         return memberService.getMemberId(loginType, loginId);
+    }
+
+    @PostMapping("/names")
+    public Map<Long, String> getMembersName(@RequestBody List<Long> memberIds) {
+
+        return memberService.getMembersName(memberIds);
     }
 }

--- a/member/src/main/java/kr/co/readingtown/member/repository/MemberRepository.java
+++ b/member/src/main/java/kr/co/readingtown/member/repository/MemberRepository.java
@@ -2,7 +2,12 @@ package kr.co.readingtown.member.repository;
 
 import kr.co.readingtown.member.domain.Member;
 import kr.co.readingtown.member.domain.enums.LoginType;
+import kr.co.readingtown.member.dto.query.MemberIdNameDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
@@ -11,4 +16,14 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Member findByLoginTypeAndLoginId(LoginType loginType, String loginId);
 
     boolean existsByUsername(String candidate);
+
+    @Query("""
+    SELECT new kr.co.readingtown.member.dto.query.MemberIdNameDto(
+        m.memberId,
+        m.username
+    )
+    FROM Member m
+    WHERE m.memberId IN :memberIds
+    """)
+    List<MemberIdNameDto> findIdAndNameByIdIn(@Param("memberIds") List<Long> memberIds);
 }

--- a/member/src/main/java/kr/co/readingtown/member/service/MemberService.java
+++ b/member/src/main/java/kr/co/readingtown/member/service/MemberService.java
@@ -47,6 +47,9 @@ public class MemberService {
 
     public Map<Long, String> getMembersName(List<Long> memberIds) {
 
+        if (memberIds == null || memberIds.isEmpty())
+            return Map.of();
+
         List<MemberIdNameDto> memberIdNameDtos = memberRepository.findIdAndNameByIdIn(memberIds);
         return memberIdNameDtos.stream()
                 .collect(Collectors.toMap(

--- a/member/src/main/java/kr/co/readingtown/member/service/MemberService.java
+++ b/member/src/main/java/kr/co/readingtown/member/service/MemberService.java
@@ -5,13 +5,17 @@ import kr.co.readingtown.member.domain.Member;
 import kr.co.readingtown.member.domain.enums.LoginType;
 import kr.co.readingtown.member.dto.DefaultProfileResponseDto;
 import kr.co.readingtown.member.dto.OnboardingRequestDto;
+import kr.co.readingtown.member.dto.query.MemberIdNameDto;
 import kr.co.readingtown.member.exception.MemberException;
 import kr.co.readingtown.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -39,6 +43,16 @@ public class MemberService {
 
         Member member = memberRepository.findByLoginTypeAndLoginId(loginType, loginId);
         return member.getMemberId();
+    }
+
+    public Map<Long, String> getMembersName(List<Long> memberIds) {
+
+        List<MemberIdNameDto> memberIdNameDtos = memberRepository.findIdAndNameByIdIn(memberIds);
+        return memberIdNameDtos.stream()
+                .collect(Collectors.toMap(
+                        MemberIdNameDto::id,
+                        MemberIdNameDto::name
+                ));
     }
 
     @Transactional

--- a/member/src/main/java/kr/co/readingtown/member/service/MemberService.java
+++ b/member/src/main/java/kr/co/readingtown/member/service/MemberService.java
@@ -55,6 +55,11 @@ public class MemberService {
                 ));
     }
 
+    public boolean getMemberExists(Long memberId) {
+
+        return memberRepository.existsById(memberId);
+    }
+
     @Transactional
     public void completeOnboarding(Long memberId, OnboardingRequestDto onboardingRequestDto) {
 

--- a/review/src/main/java/kr/co/readingtown/review/client/MemberClient.java
+++ b/review/src/main/java/kr/co/readingtown/review/client/MemberClient.java
@@ -1,0 +1,18 @@
+package kr.co.readingtown.review.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+import java.util.Map;
+
+@FeignClient(
+        name = "review-member-client",
+        url = "${server.base-uri}"
+)
+public interface MemberClient {
+
+    @PostMapping("/internal/members/name")
+    Map<Long, String> getMembersName(@RequestBody List<Long> memberIds);
+}

--- a/review/src/main/java/kr/co/readingtown/review/domain/Review.java
+++ b/review/src/main/java/kr/co/readingtown/review/domain/Review.java
@@ -23,6 +23,10 @@ public class Review extends BaseEntity {
     @Lob
     private String content;
 
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
     @Builder
     public Review(Long bookId, Long memberId, String content) {
         this.bookId = bookId;

--- a/review/src/main/java/kr/co/readingtown/review/dto/query/ReviewContentAndAuthorNameDto.java
+++ b/review/src/main/java/kr/co/readingtown/review/dto/query/ReviewContentAndAuthorNameDto.java
@@ -1,0 +1,7 @@
+package kr.co.readingtown.review.dto.query;
+
+public record ReviewContentAndAuthorNameDto(
+        Long memberId,
+        String content
+) {
+}

--- a/review/src/main/java/kr/co/readingtown/review/dto/query/ReviewIdAndContentDto.java
+++ b/review/src/main/java/kr/co/readingtown/review/dto/query/ReviewIdAndContentDto.java
@@ -1,0 +1,7 @@
+package kr.co.readingtown.review.dto.query;
+
+public record ReviewIdAndContentDto(
+        Long reviewId,
+        String content
+) {
+}

--- a/review/src/main/java/kr/co/readingtown/review/dto/request/ReviewRequestDto.java
+++ b/review/src/main/java/kr/co/readingtown/review/dto/request/ReviewRequestDto.java
@@ -1,0 +1,6 @@
+package kr.co.readingtown.review.dto.request;
+
+public record ReviewRequestDto(
+        String content
+) {
+}

--- a/review/src/main/java/kr/co/readingtown/review/dto/response/ReviewResponseDto.java
+++ b/review/src/main/java/kr/co/readingtown/review/dto/response/ReviewResponseDto.java
@@ -1,0 +1,26 @@
+package kr.co.readingtown.review.dto.response;
+
+import kr.co.readingtown.review.domain.Review;
+import kr.co.readingtown.review.dto.query.ReviewIdAndContentDto;
+
+public record ReviewResponseDto(
+        Long reviewId,
+        String content
+) {
+
+    public static ReviewResponseDto toReviewResponseDto(Review review) {
+
+        return new ReviewResponseDto(
+                review.getReviewId(),
+                review.getContent()
+        );
+    }
+
+    public static ReviewResponseDto toReviewResponseDto(ReviewIdAndContentDto dto) {
+
+        return new ReviewResponseDto(
+                dto.reviewId(),
+                dto.content()
+        );
+    }
+}

--- a/review/src/main/java/kr/co/readingtown/review/dto/response/ReviewWithAuthorResponseDto.java
+++ b/review/src/main/java/kr/co/readingtown/review/dto/response/ReviewWithAuthorResponseDto.java
@@ -1,0 +1,7 @@
+package kr.co.readingtown.review.dto.response;
+
+public record ReviewWithAuthorResponseDto(
+        String authorName,
+        String content
+) {
+}

--- a/review/src/main/java/kr/co/readingtown/review/exception/ReviewErrorCode.java
+++ b/review/src/main/java/kr/co/readingtown/review/exception/ReviewErrorCode.java
@@ -10,9 +10,10 @@ public enum ReviewErrorCode implements ErrorCode {
 
     REVIEW_NOT_FOUND(5001, "해당 책에 대한 회원의 리뷰가 존재하지 않습니다."),
     REVIEW_ALREADY_EXISTS(5002, "해당 책에 대해 이미 작성한 리뷰가 존재합니다."),
+    REVIEW_AUTHOR_MISMATCH(5003, "리뷰 작성자와 요청한 회원이 일치하지 않습니다."),
 
-    REVIEW_MEMBER_NOT_FOUND(5003, "해당 회원은 존재하지 않습니다."),
-    REVIEW_BOOK_NOT_FOUND(5004, "해당 책은 존재하지 않습니다.");
+    REVIEW_MEMBER_NOT_FOUND(5010, "해당 회원은 존재하지 않습니다."),
+    REVIEW_BOOK_NOT_FOUND(5011, "해당 책은 존재하지 않습니다.");
 
     private final int errorCode;
     private final String errorMessage;

--- a/review/src/main/java/kr/co/readingtown/review/exception/ReviewErrorCode.java
+++ b/review/src/main/java/kr/co/readingtown/review/exception/ReviewErrorCode.java
@@ -9,7 +9,10 @@ import lombok.Getter;
 public enum ReviewErrorCode implements ErrorCode {
 
     REVIEW_NOT_FOUND(5001, "해당 책에 대한 회원의 리뷰가 존재하지 않습니다."),
-    REVIEW_ALREADY_EXISTS(5002, "해당 책에 대해 이미 작성한 리뷰가 존재합니다.");
+    REVIEW_ALREADY_EXISTS(5002, "해당 책에 대해 이미 작성한 리뷰가 존재합니다."),
+
+    REVIEW_MEMBER_NOT_FOUND(5003, "해당 회원은 존재하지 않습니다."),
+    REVIEW_BOOK_NOT_FOUND(5004, "해당 책은 존재하지 않습니다.");
 
     private final int errorCode;
     private final String errorMessage;

--- a/review/src/main/java/kr/co/readingtown/review/exception/ReviewErrorCode.java
+++ b/review/src/main/java/kr/co/readingtown/review/exception/ReviewErrorCode.java
@@ -1,0 +1,16 @@
+package kr.co.readingtown.review.exception;
+
+import kr.co.readingtown.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ReviewErrorCode implements ErrorCode {
+
+    REVIEW_NOT_FOUND(5001, "해당 책에 대한 회원의 리뷰가 존재하지 않습니다."),
+    REVIEW_ALREADY_EXISTS(5002, "해당 책에 대해 이미 작성한 리뷰가 존재합니다.");
+
+    private final int errorCode;
+    private final String errorMessage;
+}

--- a/review/src/main/java/kr/co/readingtown/review/exception/ReviewException.java
+++ b/review/src/main/java/kr/co/readingtown/review/exception/ReviewException.java
@@ -1,0 +1,22 @@
+package kr.co.readingtown.review.exception;
+
+import kr.co.readingtown.common.exception.CustomException;
+
+public class ReviewException extends CustomException {
+
+    public ReviewException(final ReviewErrorCode reviewErrorCode) {
+        super(reviewErrorCode);
+    }
+
+    public static class ReviewNotFound extends ReviewException {
+        public ReviewNotFound() {
+            super(ReviewErrorCode.REVIEW_NOT_FOUND);
+        }
+    }
+
+    public static class ReviewAlreadyExists extends ReviewException {
+        public ReviewAlreadyExists() {
+            super(ReviewErrorCode.REVIEW_ALREADY_EXISTS);
+        }
+    }
+}

--- a/review/src/main/java/kr/co/readingtown/review/exception/ReviewException.java
+++ b/review/src/main/java/kr/co/readingtown/review/exception/ReviewException.java
@@ -20,6 +20,12 @@ public class ReviewException extends CustomException {
         }
     }
 
+    public static class ReviewAuthorMismatch extends ReviewException {
+        public ReviewAuthorMismatch() {
+            super(ReviewErrorCode.REVIEW_AUTHOR_MISMATCH);
+        }
+    }
+
     public static class ReviewMemberNotFound extends ReviewException {
         public ReviewMemberNotFound() {
             super(ReviewErrorCode.REVIEW_MEMBER_NOT_FOUND);

--- a/review/src/main/java/kr/co/readingtown/review/exception/ReviewException.java
+++ b/review/src/main/java/kr/co/readingtown/review/exception/ReviewException.java
@@ -19,4 +19,16 @@ public class ReviewException extends CustomException {
             super(ReviewErrorCode.REVIEW_ALREADY_EXISTS);
         }
     }
+
+    public static class ReviewMemberNotFound extends ReviewException {
+        public ReviewMemberNotFound() {
+            super(ReviewErrorCode.REVIEW_MEMBER_NOT_FOUND);
+        }
+    }
+
+    public static class ReviewBookNotFound extends ReviewException {
+        public ReviewBookNotFound() {
+            super(ReviewErrorCode.REVIEW_BOOK_NOT_FOUND);
+        }
+    }
 }

--- a/review/src/main/java/kr/co/readingtown/review/externalapi/ExternalReviewController.java
+++ b/review/src/main/java/kr/co/readingtown/review/externalapi/ExternalReviewController.java
@@ -1,0 +1,58 @@
+package kr.co.readingtown.review.externalapi;
+
+import kr.co.readingtown.review.dto.request.ReviewRequestDto;
+import kr.co.readingtown.review.dto.response.ReviewResponseDto;
+import kr.co.readingtown.review.dto.response.ReviewWithAuthorResponseDto;
+import kr.co.readingtown.review.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/books")
+public class ExternalReviewController {
+
+    private final ReviewService reviewService;
+
+    @PostMapping("/{bookId}/review")
+    public ReviewResponseDto createReview(
+            @PathVariable Long bookId,
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody ReviewRequestDto reviewCreateDto) {
+
+        return reviewService.createReview(bookId, memberId, reviewCreateDto);
+    }
+
+    @PatchMapping("/review/{reviewId}")
+    public ReviewResponseDto updateReview(
+            @PathVariable Long reviewId,
+            @RequestBody ReviewRequestDto reviewUpdateDto) {
+
+        return reviewService.updateReview(reviewId, reviewUpdateDto);
+    }
+
+    @GetMapping("/{bookId}/reviews/me")
+    public ReviewResponseDto getMyReview(
+            @PathVariable Long bookId,
+            @AuthenticationPrincipal Long memberId) {
+
+        return reviewService.getReviewByMemberId(bookId, memberId);
+    }
+
+    @GetMapping("/{bookId}/reviews")
+    public List<ReviewWithAuthorResponseDto> getReviews(@PathVariable Long bookId) {
+
+        return reviewService.getReviews(bookId);
+    }
+
+    @GetMapping("/{bookId}/reviews/{memberId}")
+    public ReviewResponseDto getReviewByMemberId(
+            @PathVariable Long bookId,
+            @PathVariable Long memberId) {
+
+        return reviewService.getReviewByMemberId(bookId, memberId);
+    }
+}

--- a/review/src/main/java/kr/co/readingtown/review/externalapi/ExternalReviewController.java
+++ b/review/src/main/java/kr/co/readingtown/review/externalapi/ExternalReviewController.java
@@ -29,9 +29,10 @@ public class ExternalReviewController {
     @PatchMapping("/review/{reviewId}")
     public ReviewResponseDto updateReview(
             @PathVariable Long reviewId,
+            @AuthenticationPrincipal Long memberId,
             @RequestBody ReviewRequestDto reviewUpdateDto) {
 
-        return reviewService.updateReview(reviewId, reviewUpdateDto);
+        return reviewService.updateReview(reviewId, memberId, reviewUpdateDto);
     }
 
     @GetMapping("/{bookId}/reviews/me")

--- a/review/src/main/java/kr/co/readingtown/review/integration/book/BookClient.java
+++ b/review/src/main/java/kr/co/readingtown/review/integration/book/BookClient.java
@@ -1,0 +1,15 @@
+package kr.co.readingtown.review.integration.book;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(
+        name = "review-book-client",
+        url = "${server.base-uri}"
+)
+public interface BookClient {
+
+    @GetMapping("/internal/books/{bookId}/exists")
+    boolean existsBook(@PathVariable("bookId") Long bookId);
+}

--- a/review/src/main/java/kr/co/readingtown/review/integration/book/BookValidator.java
+++ b/review/src/main/java/kr/co/readingtown/review/integration/book/BookValidator.java
@@ -1,0 +1,21 @@
+package kr.co.readingtown.review.integration.book;
+
+import kr.co.readingtown.review.exception.ReviewException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BookValidator {
+
+    private final BookClient bookClient;
+
+    // bookId 존재하는지 확인
+    public void validateBookExists(Long bookId) {
+
+        boolean exists = bookClient.existsBook(bookId);
+        if (!exists) {
+            throw new ReviewException.ReviewBookNotFound();
+        }
+    }
+}

--- a/review/src/main/java/kr/co/readingtown/review/integration/member/MemberClient.java
+++ b/review/src/main/java/kr/co/readingtown/review/integration/member/MemberClient.java
@@ -1,6 +1,8 @@
-package kr.co.readingtown.review.client;
+package kr.co.readingtown.review.integration.member;
 
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -13,6 +15,9 @@ import java.util.Map;
 )
 public interface MemberClient {
 
-    @PostMapping("/internal/members/name")
+    @PostMapping("/internal/members/names")
     Map<Long, String> getMembersName(@RequestBody List<Long> memberIds);
+
+    @GetMapping("/internal/members/{memberId}/exists")
+    boolean existsMember(@PathVariable("memberId") Long memberId);
 }

--- a/review/src/main/java/kr/co/readingtown/review/integration/member/MemberReader.java
+++ b/review/src/main/java/kr/co/readingtown/review/integration/member/MemberReader.java
@@ -1,0 +1,19 @@
+package kr.co.readingtown.review.integration.member;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class MemberReader {
+
+    private final MemberClient memberClient;
+
+    public Map<Long, String> getMembersName(List<Long> memberIds) {
+
+        return memberClient.getMembersName(memberIds);
+    }
+}

--- a/review/src/main/java/kr/co/readingtown/review/integration/member/MemberReader.java
+++ b/review/src/main/java/kr/co/readingtown/review/integration/member/MemberReader.java
@@ -3,8 +3,10 @@ package kr.co.readingtown.review.integration.member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Component
 @RequiredArgsConstructor
@@ -12,8 +14,15 @@ public class MemberReader {
 
     private final MemberClient memberClient;
 
-    public Map<Long, String> getMembersName(List<Long> memberIds) {
+    public Map<Long, String> getMemberNames(List<Long> memberIds) {
 
-        return memberClient.getMembersName(memberIds);
+        if (memberIds == null || memberIds.isEmpty())
+            return Collections.emptyMap();
+        List<Long> distinctIds = memberIds.stream()
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+
+        return memberClient.getMembersName(distinctIds);
     }
 }

--- a/review/src/main/java/kr/co/readingtown/review/integration/member/MemberValidator.java
+++ b/review/src/main/java/kr/co/readingtown/review/integration/member/MemberValidator.java
@@ -1,0 +1,22 @@
+package kr.co.readingtown.review.integration.member;
+
+import kr.co.readingtown.review.exception.ReviewException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberValidator {
+
+    private final MemberClient memberClient;
+
+
+    // memberId 존재하는지 확인
+    public void validateMemberExists(Long memberId) {
+
+        boolean exists = memberClient.existsMember(memberId);
+        if (!exists) {
+            throw new ReviewException.ReviewMemberNotFound();
+        }
+    }
+}

--- a/review/src/main/java/kr/co/readingtown/review/repository/ReviewRepository.java
+++ b/review/src/main/java/kr/co/readingtown/review/repository/ReviewRepository.java
@@ -1,0 +1,37 @@
+package kr.co.readingtown.review.repository;
+
+import kr.co.readingtown.review.domain.Review;
+import kr.co.readingtown.review.dto.query.ReviewContentAndAuthorNameDto;
+import kr.co.readingtown.review.dto.query.ReviewIdAndContentDto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    boolean existsByBookIdAndMemberId(Long bookId, Long memberId);
+
+    @Query("""
+    SELECT new kr.co.readingtown.review.dto.query.ReviewIdAndContentDto(
+        rv.reviewId,
+        rv.content
+    )
+    FROM Review rv
+    WHERE rv.bookId = :bookId
+        AND rv.memberId = :memberId
+    """)
+    Optional<ReviewIdAndContentDto> findReviewByBookIdAndMemberId(@Param("bookId") Long bookId, @Param("memberId") Long memberId);
+
+    @Query("""
+    SELECT new kr.co.readingtown.review.dto.query.ReviewContentAndAuthorNameDto(
+        rv.memberId,
+        rv.content
+    )
+    FROM Review rv
+    WHERE rv.bookId = :bookId
+    """)
+    List<ReviewContentAndAuthorNameDto> findReviewByBookId(@Param("bookId") Long bookId);
+}

--- a/review/src/main/java/kr/co/readingtown/review/service/ReviewService.java
+++ b/review/src/main/java/kr/co/readingtown/review/service/ReviewService.java
@@ -1,6 +1,7 @@
 package kr.co.readingtown.review.service;
 
-import kr.co.readingtown.review.client.MemberClient;
+import kr.co.readingtown.review.integration.book.BookValidator;
+import kr.co.readingtown.review.integration.member.MemberClient;
 import kr.co.readingtown.review.domain.Review;
 import kr.co.readingtown.review.dto.query.ReviewContentAndAuthorNameDto;
 import kr.co.readingtown.review.dto.query.ReviewIdAndContentDto;
@@ -8,6 +9,7 @@ import kr.co.readingtown.review.dto.request.ReviewRequestDto;
 import kr.co.readingtown.review.dto.response.ReviewResponseDto;
 import kr.co.readingtown.review.dto.response.ReviewWithAuthorResponseDto;
 import kr.co.readingtown.review.exception.ReviewException;
+import kr.co.readingtown.review.integration.member.MemberValidator;
 import kr.co.readingtown.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,6 +25,8 @@ import java.util.Map;
 public class ReviewService {
 
     private final MemberClient memberClient;
+    private final BookValidator bookValidator;
+    private final MemberValidator memberValidator;
     private final ReviewRepository reviewRepository;
 
     // 책 감상평 등록
@@ -32,6 +36,7 @@ public class ReviewService {
         if (reviewRepository.existsByBookIdAndMemberId(bookId, memberId)) {
             throw new ReviewException.ReviewAlreadyExists();
         }
+        bookValidator.validateBookExists(bookId);
 
         Review newReview = Review.builder()
                 .bookId(bookId)
@@ -59,6 +64,9 @@ public class ReviewService {
     // 특정 책에 대한 특정 회원의 감상평 조회
     public ReviewResponseDto getReviewByMemberId(Long bookId, Long memberId) {
 
+        bookValidator.validateBookExists(bookId);
+        memberValidator.validateMemberExists(memberId);
+
         ReviewIdAndContentDto myReview = reviewRepository.findReviewByBookIdAndMemberId(bookId, memberId)
                 .orElseThrow(ReviewException.ReviewNotFound::new);
 
@@ -68,6 +76,7 @@ public class ReviewService {
     // 특정 책의 모든 감상평 조회
     public List<ReviewWithAuthorResponseDto> getReviews(Long bookId) {
 
+        bookValidator.validateBookExists(bookId);
         List<ReviewContentAndAuthorNameDto> reviews = reviewRepository.findReviewByBookId(bookId);
         if (reviews.isEmpty()) {
             return Collections.emptyList();

--- a/review/src/main/java/kr/co/readingtown/review/service/ReviewService.java
+++ b/review/src/main/java/kr/co/readingtown/review/service/ReviewService.java
@@ -1,7 +1,6 @@
 package kr.co.readingtown.review.service;
 
 import kr.co.readingtown.review.integration.book.BookValidator;
-import kr.co.readingtown.review.integration.member.MemberClient;
 import kr.co.readingtown.review.domain.Review;
 import kr.co.readingtown.review.dto.query.ReviewContentAndAuthorNameDto;
 import kr.co.readingtown.review.dto.query.ReviewIdAndContentDto;
@@ -9,6 +8,7 @@ import kr.co.readingtown.review.dto.request.ReviewRequestDto;
 import kr.co.readingtown.review.dto.response.ReviewResponseDto;
 import kr.co.readingtown.review.dto.response.ReviewWithAuthorResponseDto;
 import kr.co.readingtown.review.exception.ReviewException;
+import kr.co.readingtown.review.integration.member.MemberReader;
 import kr.co.readingtown.review.integration.member.MemberValidator;
 import kr.co.readingtown.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +24,7 @@ import java.util.Map;
 @Transactional(readOnly = true)
 public class ReviewService {
 
-    private final MemberClient memberClient;
+    private final MemberReader memberReader;
     private final BookValidator bookValidator;
     private final MemberValidator memberValidator;
     private final ReviewRepository reviewRepository;
@@ -91,7 +91,8 @@ public class ReviewService {
         List<Long> memberIds = reviews.stream()
                 .map(ReviewContentAndAuthorNameDto::memberId)
                 .toList();
-        return memberClient.getMembersName(memberIds);
+
+        return memberReader.getMembersName(memberIds);
     }
 
     private List<ReviewWithAuthorResponseDto> convertToReviewWithAuthorResponseDto(

--- a/review/src/main/java/kr/co/readingtown/review/service/ReviewService.java
+++ b/review/src/main/java/kr/co/readingtown/review/service/ReviewService.java
@@ -1,0 +1,95 @@
+package kr.co.readingtown.review.service;
+
+import kr.co.readingtown.review.client.MemberClient;
+import kr.co.readingtown.review.domain.Review;
+import kr.co.readingtown.review.dto.query.ReviewContentAndAuthorNameDto;
+import kr.co.readingtown.review.dto.query.ReviewIdAndContentDto;
+import kr.co.readingtown.review.dto.request.ReviewRequestDto;
+import kr.co.readingtown.review.dto.response.ReviewResponseDto;
+import kr.co.readingtown.review.dto.response.ReviewWithAuthorResponseDto;
+import kr.co.readingtown.review.exception.ReviewException;
+import kr.co.readingtown.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+
+    private final MemberClient memberClient;
+    private final ReviewRepository reviewRepository;
+
+    // 책 감상평 등록
+    @Transactional
+    public ReviewResponseDto createReview(Long bookId, Long memberId, ReviewRequestDto reviewCreateDto) {
+
+        if (reviewRepository.existsByBookIdAndMemberId(bookId, memberId)) {
+            throw new ReviewException.ReviewAlreadyExists();
+        }
+
+        Review newReview = Review.builder()
+                .bookId(bookId)
+                .memberId(memberId)
+                .content(reviewCreateDto.content())
+                .build();
+        Review saved = reviewRepository.save(newReview);
+
+        return ReviewResponseDto.toReviewResponseDto(saved);
+    }
+
+    // 책 감상평 수정
+    @Transactional
+    public ReviewResponseDto updateReview(Long reviewId, ReviewRequestDto reviewUpdateDto) {
+
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(ReviewException.ReviewNotFound::new);
+
+        review.updateContent(reviewUpdateDto.content());
+        Review saved = reviewRepository.save(review);
+
+        return ReviewResponseDto.toReviewResponseDto(saved);
+    }
+
+    // 특정 책에 대한 특정 회원의 감상평 조회
+    public ReviewResponseDto getReviewByMemberId(Long bookId, Long memberId) {
+
+        ReviewIdAndContentDto myReview = reviewRepository.findReviewByBookIdAndMemberId(bookId, memberId)
+                .orElseThrow(ReviewException.ReviewNotFound::new);
+
+        return ReviewResponseDto.toReviewResponseDto(myReview);
+    }
+
+    // 특정 책의 모든 감상평 조회
+    public List<ReviewWithAuthorResponseDto> getReviews(Long bookId) {
+
+        List<ReviewContentAndAuthorNameDto> reviews = reviewRepository.findReviewByBookId(bookId);
+        if (reviews.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Map<Long, String> memberNames = getMemberNamesForReviews(reviews);
+        return convertToReviewWithAuthorResponseDto(reviews, memberNames);
+    }
+
+    private Map<Long, String> getMemberNamesForReviews(List<ReviewContentAndAuthorNameDto> reviews) {
+
+        List<Long> memberIds = reviews.stream()
+                .map(ReviewContentAndAuthorNameDto::memberId)
+                .toList();
+        return memberClient.getMembersName(memberIds);
+    }
+
+    private List<ReviewWithAuthorResponseDto> convertToReviewWithAuthorResponseDto(
+            List<ReviewContentAndAuthorNameDto> reviews, Map<Long, String> memberNames) {
+
+        return reviews.stream()
+                .map(review -> new ReviewWithAuthorResponseDto(review.content(), memberNames.get(review.memberId())))
+                .toList();
+    }
+}


### PR DESCRIPTION
## ✨ Issue Number
> close #32 

## 📄 작업 내용 (주요 변경 사항)

- Book API 구현 완료
- 외부 모듈 통해서 검증해야 하는 로직은 (ex. memberId의 회원 존재하는지 확인하는) 따로 memberValidator, bookValidator를 만들어주었습니다.

## 💬 리뷰 요구사항
- 외부 모듈의 api를 호출하는 부분을 서비스 클래스에 직접 작성하는 것 보다 따로 클래스를 빼는게 좋다고 하는데 어떻게 생각하시나요?? 
이유1 : 서비스 계층의 역할은 비지니스 로직 흐름에 집중하는 것인데 외부 모듈 api는 통신 로직이기 때문
이유2 : 외부 모듈 api가 바뀌더라도 서비스 계층 수정없이 통신 로직 쪽만 수정하기 위함
-> 이러한 이유로 validator만 지금 따로 빼둔 상태인데 '멤버 이름 조회' 같은 조회 api들도 따로 클래스 만들어서 빼둘지 고민입니다

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 도서 존재 여부 확인 및 조회 기능이 추가되었습니다.
  * 회원 이름 일괄 조회 및 회원 존재 여부 확인 기능이 추가되었습니다.
  * 리뷰 작성, 수정, 단일/전체 조회, 작성자명 포함 조회 등 리뷰 관련 API가 추가되었습니다.
  * 리뷰 관련 예외 및 오류 코드가 신설되어 상세한 오류 메시지를 제공합니다.
  * Swagger UI 및 API 문서에 인증 없이 접근할 수 있습니다.

* **버그 수정**
  * 해당 없음.

* **문서화**
  * Swagger API 문서 스캔 범위가 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->