### PR TITLE
Feat: 채팅 관련 기능

### DIFF
--- a/api/src/main/java/kr/co/readingtown/swagger/SwaggerConfig.java
+++ b/api/src/main/java/kr/co/readingtown/swagger/SwaggerConfig.java
@@ -25,7 +25,8 @@ public class SwaggerConfig {
                         "kr.co.readingtown.member.externalapi",
                         "kr.co.readingtown.review.externalapi",
                         "kr.co.readingtown.book.externalapi",
-                        "kr.co.readingtown.bookhouse.externalapi"
+                        "kr.co.readingtown.bookhouse.externalapi",
+                        "kr.co.readingtown.chat.externalapi"
                 )
                 .build();
     }

--- a/chat/src/main/java/kr/co/readingtown/chat/domain/Chatroom.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/domain/Chatroom.java
@@ -20,6 +20,18 @@ public class Chatroom extends BaseEntity {
     @Column(name = "requester_id")
     private Long requesterId;
 
+    public void removeOwnerId() {
+        this.ownerId = null;
+    }
+
+    public void removeRequesterId() {
+        this.requesterId = null;
+    }
+
+    public boolean isEmpty() {
+        return ownerId == null && requesterId == null;
+    }
+
     @Builder
     public Chatroom(Long ownerId, Long requesterId) {
         this.ownerId = ownerId;

--- a/chat/src/main/java/kr/co/readingtown/chat/domain/Chatroom.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/domain/Chatroom.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import kr.co.readingtown.common.entity.BaseEntity;
 import lombok.*;
 
+import java.util.Objects;
+
 @Entity
 @Getter
 @Table(name = "chatrooms")
@@ -26,6 +28,10 @@ public class Chatroom extends BaseEntity {
 
     public void removeRequesterId() {
         this.requesterId = null;
+    }
+
+    public boolean hasMember(Long memberId) {
+        return Objects.equals(ownerId, memberId) || Objects.equals(requesterId, memberId);
     }
 
     public boolean isEmpty() {

--- a/chat/src/main/java/kr/co/readingtown/chat/domain/Message.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/domain/Message.java
@@ -18,9 +18,8 @@ public class Message extends BaseEntity {
     @Column(name = "message_id")
     private Long messageId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chatroom_id")
-    private Chatroom chatroom;
+    @Column(name = "chatroom_id")
+    private Long chatroomId;
 
     @Column(name = "sender_id")
     private Long senderId;
@@ -33,8 +32,8 @@ public class Message extends BaseEntity {
     private LocalDateTime sentTime;
 
     @Builder
-    public Message(Chatroom chatroom, Long senderId, String content) {
-        this.chatroom = chatroom;
+    public Message(Long chatroomId, Long senderId, String content) {
+        this.chatroomId = chatroomId;
         this.senderId = senderId;
         this.content = content;
     }

--- a/chat/src/main/java/kr/co/readingtown/chat/dto/response/ChatExchangedBookInfoResponse.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/dto/response/ChatExchangedBookInfoResponse.java
@@ -12,19 +12,19 @@ public record ChatExchangedBookInfoResponse(
             BookInfoResponse partnerBookInfo
     ) {
         ExchangedBookDetail myBook = new ExchangedBookDetail(
-                exchangedBookResponse.myBook().exchangeStatusId(),
-                exchangedBookResponse.myBook().bookhouseId(),
-                myBookInfo.bookName(),
-                myBookInfo.bookImage(),
-                exchangedBookResponse.myBook().isAccepted()
+                exchangedBookResponse.myBook() != null ? exchangedBookResponse.myBook().exchangeStatusId() : null,
+                exchangedBookResponse.myBook() != null ? exchangedBookResponse.myBook().bookhouseId() : null,
+                myBookInfo != null ? myBookInfo.bookName() : null,
+                myBookInfo != null ? myBookInfo.bookImage() : null,
+                exchangedBookResponse.myBook() != null ? exchangedBookResponse.myBook().isAccepted() : null
         );
 
         ExchangedBookDetail partnerBook = new ExchangedBookDetail(
-                exchangedBookResponse.partnerBook().exchangeStatusId(),
-                exchangedBookResponse.partnerBook().bookhouseId(),
-                partnerBookInfo.bookName(),
-                partnerBookInfo.bookImage(),
-                exchangedBookResponse.partnerBook().isAccepted()
+                exchangedBookResponse.partnerBook() != null ? exchangedBookResponse.partnerBook().exchangeStatusId() : null,
+                exchangedBookResponse.partnerBook() != null ? exchangedBookResponse.partnerBook().bookhouseId() : null,
+                partnerBookInfo != null ? partnerBookInfo.bookName() : null,
+                partnerBookInfo != null ? partnerBookInfo.bookImage() : null,
+                exchangedBookResponse.partnerBook() != null ? exchangedBookResponse.partnerBook().isAccepted() : null
         );
 
         return new ChatExchangedBookInfoResponse(myBook, partnerBook);

--- a/chat/src/main/java/kr/co/readingtown/chat/dto/response/ChatroomPreviewResponseDto.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/dto/response/ChatroomPreviewResponseDto.java
@@ -1,0 +1,23 @@
+package kr.co.readingtown.chat.dto.response;
+
+import kr.co.readingtown.chat.domain.Message;
+
+import java.time.LocalDateTime;
+
+public record ChatroomPreviewResponseDto(
+        Long chatroomId,
+        String partnerName,
+        String lastMessage,
+        LocalDateTime lastMessageTime
+) {
+
+    public static ChatroomPreviewResponseDto of(Long chatroomId, String partnerName, Message message) {
+
+        return new ChatroomPreviewResponseDto(
+                chatroomId,
+                partnerName,
+                message != null ? message.getContent() : null,
+                message != null ? message.getSentTime() : null
+        );
+    }
+}

--- a/chat/src/main/java/kr/co/readingtown/chat/dto/response/CursorPagingResponseDto.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/dto/response/CursorPagingResponseDto.java
@@ -1,0 +1,7 @@
+package kr.co.readingtown.chat.dto.response;
+
+public record CursorPagingResponseDto(
+        Long nextCursor,
+        boolean hasMore
+) {
+}

--- a/chat/src/main/java/kr/co/readingtown/chat/dto/response/MessageListResponseDto.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/dto/response/MessageListResponseDto.java
@@ -1,0 +1,10 @@
+package kr.co.readingtown.chat.dto.response;
+
+import java.util.List;
+
+public record MessageListResponseDto(
+        Long myMemberId,
+        List<MessageResponseDto> message,
+        CursorPagingResponseDto paging
+) {
+}

--- a/chat/src/main/java/kr/co/readingtown/chat/dto/response/MessageResponseDto.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/dto/response/MessageResponseDto.java
@@ -1,0 +1,23 @@
+package kr.co.readingtown.chat.dto.response;
+
+import kr.co.readingtown.chat.domain.Message;
+
+import java.time.LocalDateTime;
+
+public record MessageResponseDto(
+        Long messageId,
+        Long senderId,
+        String messageText,
+        LocalDateTime sentTime
+) {
+
+    public static MessageResponseDto of(Message message) {
+
+        return new MessageResponseDto(
+                message.getMessageId(),
+                message.getSenderId(),
+                message.getContent(),
+                message.getSentTime()
+        );
+    }
+}

--- a/chat/src/main/java/kr/co/readingtown/chat/exception/ChatErrorCode.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/exception/ChatErrorCode.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ChatErrorCode implements ErrorCode {
 
-    CHATROOM_NOT_FOUND(9001, "해당 채팅룸은 존재하지 않습니다.");
+    CHATROOM_NOT_FOUND(9001, "해당 채팅룸은 존재하지 않습니다."),
+    MEMBER_NOT_IN_CHATROOM(9002, "해당 멤버는 채팅룸에 속해있지 않습니다.");
 
     private final int errorCode;
     private final String errorMessage;

--- a/chat/src/main/java/kr/co/readingtown/chat/exception/ChatException.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/exception/ChatException.java
@@ -13,4 +13,10 @@ public class ChatException extends CustomException {
             super(ChatErrorCode.CHATROOM_NOT_FOUND);
         }
     }
+
+    public static class MemberNotInChatroom extends ChatException {
+        public MemberNotInChatroom() {
+            super(ChatErrorCode.MEMBER_NOT_IN_CHATROOM);
+        }
+    }
 }

--- a/chat/src/main/java/kr/co/readingtown/chat/externalapi/ExternalChatController.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/externalapi/ExternalChatController.java
@@ -1,22 +1,27 @@
 package kr.co.readingtown.chat.externalapi;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.readingtown.chat.dto.request.ChatRequestDto;
-import kr.co.readingtown.chat.dto.response.ChatExchangedBookInfoResponse;
-import kr.co.readingtown.chat.dto.response.ChatMemberInfoResponse;
-import kr.co.readingtown.chat.dto.response.ChatroomIdResponse;
+import kr.co.readingtown.chat.dto.response.*;
 import kr.co.readingtown.chat.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/chatrooms")
+@Tag(name = "Chat API", description = "채팅 관련 API")
 public class ExternalChatController {
 
     private final ChatService chatService;
 
     @PostMapping
+    @Operation(summary = "채팅룸 생성", description = "서재 페이지에서 채팅 버튼을 눌러 채팅룸을 생성하는 API 입니다. 생성한 채팅룸 id를 반환합니다.")
     public ChatroomIdResponse createChatroom(
             @RequestBody ChatRequestDto chatRequestDto,
             @AuthenticationPrincipal Long memberId) {
@@ -25,16 +30,52 @@ public class ExternalChatController {
     }
 
     @GetMapping("/{chatroomId}/books")
+    @Operation(summary = "교환 책 정보 조회", description = "채팅 페이지에서 교환 책 정보를 조회하는 API 입니다.")
     public ChatExchangedBookInfoResponse getExchangedBookInfo(@PathVariable Long chatroomId) {
 
         return chatService.getExchangedBookInfo(chatroomId);
     }
 
     @GetMapping("/{chatroomId}/partner/profile")
+    @Operation(summary = "채팅 상대방 정보 조회", description = "채팅 상대방 정보(id, 닉네임, 프로필 사진)를 조회하는 API 입니다.")
     public ChatMemberInfoResponse getPartnerInfo(
             @PathVariable Long chatroomId,
             @AuthenticationPrincipal Long myId
     ) {
         return chatService.getPartnerInfo(chatroomId, myId);
     }
+
+    @GetMapping("/{chatroomId}/messages")
+    @Operation(summary = "이전 채팅 메시지 조회", description = "이전 채팅 메시지를 조회하는 API 입니다. 커서 기반 페이지네이션을 적용합니다.")
+    public MessageListResponseDto getChatMessage(
+            @PathVariable Long chatroomId,
+
+            @Parameter(description = "가져올 메시지 개수 (ex.50)")
+            @RequestParam int limit,
+
+            @Parameter(description = "이 커서(메시지 ID) 이전의 메시지를 조회")
+            @RequestParam Long before,
+
+            @AuthenticationPrincipal Long myId) {
+
+        return chatService.getChatMessage(chatroomId, limit, before, myId);
+    }
+
+    @GetMapping
+    @Operation(summary = "채팅룸 리스트 조회", description = "로그인 한 유저가 속한 채팅룸 리스트를 조회하는 API 입니다.")
+    public List<ChatroomPreviewResponseDto> getMyChatroom(@AuthenticationPrincipal Long myId) {
+
+        return chatService.getMyChatroom(myId);
+    }
+
+    @DeleteMapping("/{chatroomId}")
+    @Operation(summary = "채팅룸 나가기", description = "특정 채팅룸을 나가는 API 입니다.")
+    public void leaveChatroom(
+            @PathVariable Long chatroomId,
+            @AuthenticationPrincipal Long myId
+    ) {
+
+        chatService.leaveChatroom(chatroomId, myId);
+    }
+
 }

--- a/chat/src/main/java/kr/co/readingtown/chat/externalapi/ExternalChatController.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/externalapi/ExternalChatController.java
@@ -51,10 +51,10 @@ public class ExternalChatController {
             @PathVariable Long chatroomId,
 
             @Parameter(description = "가져올 메시지 개수 (ex.50)")
-            @RequestParam int limit,
+            @RequestParam(defaultValue = "50") int limit,
 
-            @Parameter(description = "이 커서(메시지 ID) 이전의 메시지를 조회")
-            @RequestParam Long before,
+            @Parameter(description = "이 커서(메시지 ID) 이전의 메시지를 조회 (선택)")
+            @RequestParam(required = false) Long before,
 
             @AuthenticationPrincipal Long myId) {
 

--- a/chat/src/main/java/kr/co/readingtown/chat/integration/bookhouse/BookhouseClient.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/integration/bookhouse/BookhouseClient.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 )
 public interface BookhouseClient {
 
+    // TODO : 이거 삭제 고려
     @PostMapping("/internal/exchange-status")
     void createExchangeStatus(@RequestBody ChatRequestDto chatRequestDto);
 

--- a/chat/src/main/java/kr/co/readingtown/chat/repository/ChatroomRepository.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/repository/ChatroomRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
@@ -16,4 +17,12 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
         AND cr.requesterId = :requesterId
     """)
     Optional<Long> findChatroomIdByMemberIds(@Param("ownerId") Long ownerId, @Param("requesterId")Long requesterId);
+
+    @Query("""
+    SELECT cr
+    FROM Chatroom cr
+    WHERE cr.requesterId = :memberId
+        OR cr.ownerId = :memberId
+    """)
+    List<Chatroom> findMyChatrooms(@Param("memberId") Long memberId);
 }

--- a/chat/src/main/java/kr/co/readingtown/chat/repository/MessageRepository.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/repository/MessageRepository.java
@@ -1,0 +1,49 @@
+package kr.co.readingtown.chat.repository;
+
+import kr.co.readingtown.chat.domain.Message;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+
+    @Query("""
+    SELECT m
+    FROM Message m
+    WHERE m.chatroomId = :chatroomId
+        AND (:before IS NULL OR m.messageId < :before)
+    ORDER BY m.messageId DESC
+    """)
+    List<Message> findMessages(@Param("chatroomId") Long chatroomId,
+                               @Param("before") Long before,
+                               Pageable pageable);
+
+
+//    @Query("""
+//    SELECT m
+//    FROM Message m
+//    WHERE m.chatroomId IN :chatroomIds
+//    AND m.createdAt = (
+//        SELECT MAX (m2.createdAt)
+//        FROM Message m2
+//        WHERE m2.chatroomId = m.chatroomId
+//    )
+//    """)
+//    List<Message> findLatestMessagesByChatrooms(@Param("chatroomIds") List<Long> chatroomIds);
+
+    @Query(value = """
+        SELECT m.*
+        FROM messages m
+        JOIN (
+            SELECT m2.chatroom_id, MAX(m2.created_at) AS latest_created_at
+            FROM messages m2
+            WHERE m2.chatroom_id IN :chatroomIds
+            GROUP BY m2.chatroom_id
+        ) latest ON latest.chatroom_id = m.chatroom_id
+        WHERE m.created_at = latest.latest_created_at
+    """, nativeQuery = true)
+    List<Message> findLatestMessagesByChatrooms(@Param("chatroomIds") List<Long> chatroomIds);
+}

--- a/chat/src/main/java/kr/co/readingtown/chat/service/ChatService.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/service/ChatService.java
@@ -145,6 +145,8 @@ public class ChatService {
 
         Chatroom chatroom = chatroomRepository.findById(chatroomId)
                 .orElseThrow(ChatException.ChatroomNotFound::new);
+        if (!chatroom.hasMember(myId))
+            throw new ChatException.MemberNotInChatroom();
 
         if (Objects.equals(chatroom.getOwnerId(), myId)) {
             chatroom.removeOwnerId();


### PR DESCRIPTION
## ✨ Issue Number
> close #43 

## 📄 작업 내용 (주요 변경 사항)

- 채팅룸의 이전 메시지 조회 API
- 내가 속한 채팅룸 리스트 조회 API
- 채팅룸 나가기 API

## 💬 리뷰 요구사항
가장 최신 메시지 조회하는 쿼리가 복잡해서 고민입니다 .. 더 좋은 쿼리가 없을까요 

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 채팅방 목록 조회(상대 이름, 최근 메시지/시간 포함)
  - 채팅 메시지 커서 기반 페이징 조회(이전 메시지 로드 지원)
  - 채팅방 나가기 기능
  - 메시지/미리보기/페이징 응답 형식 추가(API 응답 개선)

- **Bug Fixes**
  - 교환 도서 정보 조회 시 Null 안전성 보강(예외 방지)

- **Documentation**
  - 외부 API 문서에 채팅 엔드포인트 및 매개변수 설명 추가
  - 외부 API 그룹 스캔 범위 확장

- **Chores**
  - 채팅 관련 오류 코드 및 예외 처리 항목 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->