### PR TITLE
fix: redirect-uri 수정

### DIFF
--- a/api/src/main/java/kr/co/readingtown/handler/OAuth2LoginSuccessHandler.java
+++ b/api/src/main/java/kr/co/readingtown/handler/OAuth2LoginSuccessHandler.java
@@ -32,6 +32,6 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
         cookieUtil.saveTokenToCookie(response, accessToken, refreshToken);
 
-        response.sendRedirect("/success.html");
+        response.sendRedirect("http://localhost:3000/home");
     }
 }


### PR DESCRIPTION
## ✨ Issue Number
> close #52 

## 📄 작업 내용 (주요 변경 사항)
로그인 성공 시 프론트 로컬 uri 로 수정

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - OAuth2 로그인 성공 후 리다이렉트 대상이 잘못되어 있던 문제를 수정했습니다. 이제 로그인 완료 시 /success.html 대신 http://localhost:3000/home으로 이동하여 즉시 홈 화면을 볼 수 있습니다. 토큰 발급과 쿠키 저장 동작은 동일하며, 추가적인 화면 흐름 변화는 없습니다. 또한 외부 페이지로의 불필요한 이동을 줄여 뒤로 가기 동작이 더욱 일관됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->