### PR TITLE
fix: cookie cross site 허용 도메인

### DIFF
--- a/common/src/main/java/kr/co/readingtown/common/util/CookieUtil.java
+++ b/common/src/main/java/kr/co/readingtown/common/util/CookieUtil.java
@@ -28,16 +28,20 @@ public class CookieUtil {
 
         // accessToken 쿠키 설정
         Cookie accessTokenCookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, accessToken);
-        // accessTokenCookie.setHttpOnly(true);
-        // accessTokenCookie.setSecure(true);
+        accessTokenCookie.setDomain(".readingtown.site");
+        accessTokenCookie.setHttpOnly(true);
+        accessTokenCookie.setSecure(true);
         accessTokenCookie.setPath("/");
+        accessTokenCookie.setAttribute("SameSite", "Lax"); //크로스 사이트 요청 시 쿠키 전송 허용
         accessTokenCookie.setMaxAge(15 * 60);
 
         // refreshToken 쿠키 설정
         Cookie refreshTokenCookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
-        // refreshTokenCookie.setHttpOnly(true);
-        // refreshTokenCookie.setSecure(true);
+        refreshTokenCookie.setDomain(".readingtown.site");
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(true);
         refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setAttribute("SameSite", "Lax");
         refreshTokenCookie.setMaxAge(7 * 24 * 60 * 60);
 
         response.addCookie(accessTokenCookie);


### PR DESCRIPTION
## ✨ Issue Number
> close #이슈번호

## 📄 작업 내용 (주요 변경 사항)
프론트에서 쿠키 값을 못 받는 문제가 있어 쿠키 도메인 설정을 추가하고 서버에서 프론트로 리다이렉트 할 때 lax 설정이 필요합니다.
SameSite=Lax는 쿠키 속성 설정하여 크로스 사이트 요청 위조(CSRF) 공격을 방지하면서도 OAuth 리다이렉트 시 쿠키 전송을 허용하는 보안 설정입니다.

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 쿠키 보안 설정을 강화했습니다: HttpOnly·Secure 활성화, 도메인 .readingtown.site 적용, 경로 "/" 지정, SameSite=Lax 설정, 만료기간 유지(액세스 15분, 리프레시 7일). 이를 통해 로그인 관련 쿠키의 안전성과 브라우저 간 호환성이 개선됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->