### PR TITLE
feat: 위경도로 동네 조회 API 추가

### DIFF
--- a/member/src/main/java/kr/co/readingtown/member/exception/MemberException.java
+++ b/member/src/main/java/kr/co/readingtown/member/exception/MemberException.java
@@ -49,8 +49,6 @@ public class MemberException extends CustomException {
     }
 
     public static class TownResolvedFailed extends MemberException {
-        public TownResolvedFailed() {
-            super(MemberErrorCode.TOWN_RESOLVED_FAILED);
-        }
+        public TownResolvedFailed() { super(MemberErrorCode.TOWN_RESOLVED_FAILED); }
     }
 }

--- a/member/src/main/java/kr/co/readingtown/member/externalapi/ExternalMemberController.java
+++ b/member/src/main/java/kr/co/readingtown/member/externalapi/ExternalMemberController.java
@@ -19,6 +19,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 
@@ -67,6 +68,15 @@ public class ExternalMemberController {
         String currentTown = memberService.getTown(memberId);
         return Map.of("currentTown",currentTown);
     }
+    
+    @GetMapping("/town/coordinates")
+    @Operation(summary = "위경도로 동네 조회", description = "위경도 좌표로 동네 정보를 조회합니다.")
+    public Map<String, String> getTownByCoordinates(@RequestParam BigDecimal longitude,
+                                                    @RequestParam BigDecimal latitude) {
+        String currentTown = memberService.getTownByCoordinates(longitude, latitude);
+        return Map.of("currentTown", currentTown);
+    }
+
 
     @PutMapping("/town")
     @Operation(summary = "동네 수정", description = "동네 정보를 수정합니다.")

--- a/member/src/main/java/kr/co/readingtown/member/service/KakaoLocationService.java
+++ b/member/src/main/java/kr/co/readingtown/member/service/KakaoLocationService.java
@@ -68,11 +68,23 @@ public class KakaoLocationService implements LocationService {
             }
             if (selected == null) selected = docs.get(0);
 
+            String depth1 = selected.path("region_1depth_name").asText("");
+            String depth2 = selected.path("region_2depth_name").asText("");
             String depth3 = selected.path("region_3depth_name").asText("");
-            if (!depth3.isBlank()) return depth3;
-
-            // fallback: 구 단위라도
-            return selected.path("region_2depth_name").asText("");
+            
+            // 시 구 동 조합
+            StringBuilder fullAddress = new StringBuilder();
+            if (!depth1.isBlank()) fullAddress.append(depth1);
+            if (!depth2.isBlank()) {
+                if (fullAddress.length() > 0) fullAddress.append(" ");
+                fullAddress.append(depth2);
+            }
+            if (!depth3.isBlank()) {
+                if (fullAddress.length() > 0) fullAddress.append(" ");
+                fullAddress.append(depth3);
+            }
+            
+            return fullAddress.toString();
         } catch (Exception e) {
             log.warn("[KAKAO coord2region] request failed: {}", e.toString());
             return "";
@@ -96,12 +108,25 @@ public class KakaoLocationService implements LocationService {
             if (!docs.isArray() || docs.size() == 0) return "";
 
             JsonNode addr = docs.get(0).path("address");
+            String depth1 = addr.path("region_1depth_name").asText("");
+            String depth2 = addr.path("region_2depth_name").asText("");
             String depth3 = addr.path("region_3depth_name").asText("");
-            if (!depth3.isBlank()) return depth3;
-
-            return addr.path("region_2depth_name").asText("");
+            
+            // 시 구 동 조합
+            StringBuilder fullAddress = new StringBuilder();
+            if (!depth1.isBlank()) fullAddress.append(depth1);
+            if (!depth2.isBlank()) {
+                if (fullAddress.length() > 0) fullAddress.append(" ");
+                fullAddress.append(depth2);
+            }
+            if (!depth3.isBlank()) {
+                if (fullAddress.length() > 0) fullAddress.append(" ");
+                fullAddress.append(depth3);
+            }
+            
+            return fullAddress.toString();
         } catch (Exception e) {
-            log.warn("[KAKAO coord2region] request failed: {}", e.toString());
+            log.warn("[KAKAO coord2address] request failed: {}", e.toString());
             return "";
         }
     }

--- a/member/src/main/java/kr/co/readingtown/member/service/MemberService.java
+++ b/member/src/main/java/kr/co/readingtown/member/service/MemberService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -238,11 +239,23 @@ public class MemberService {
             throw new MemberException.TownResolvedFailed();
         }
 
-        // 경위도 -> 동네명 해석 (coord2region → 실패 시 coord2address → 둘 다 실패 시 LocationException.TownResolveFailed)
+        // 경위도 -> 동네명
         String currentTown = locationService.resolveTown(updateTownRequestDto.getLongitude(), updateTownRequestDto.getLatitude());
 
         member.updateTown(updateTownRequestDto.getLongitude(), updateTownRequestDto.getLatitude(), currentTown);
         return currentTown;
+    }
+    
+    public String getTownByCoordinates(BigDecimal longitude, BigDecimal latitude) {
+        // 범위 검증 (-90~90, -180~180)
+        if (latitude != null && longitude != null) {
+            double lat = latitude.doubleValue();
+            double lon = longitude.doubleValue();
+            if (lat < -90 || lat > 90 || lon < -180 || lon > 180) {
+                throw new MemberException.TownResolvedFailed();
+            }
+        }
+        return locationService.resolveTown(longitude, latitude);
     }
 
     public ProfileResponseDto getProfile(Long memberId) {


### PR DESCRIPTION
## ✨ Issue Number
> close #94 

## 📄 작업 내용 (주요 변경 사항)
api 새로 추가하고 currentTown 설정은 현재 동네 조회할 때 기존에 동단위가 아닌 전체 주소로 반환되게 수정하였습니다.

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 위도/경도를 받아 현재 동네를 조회하는 GET /town/coordinates 엔드포인트 추가
  - 좌표 기반 동네 조회 시 입력 좌표의 유효성 검사(경도/위도 범위) 적용
- Refactor
  - 카카오 위치 응답을 동·면·리 단일명 대신 시/군/구까지 포함한 전체 주소로 조합해 반환하도록 개선
- Style
  - 예외 처리 로그 메시지와 생성자 포맷 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->