### PR TITLE
Fix: Bookhouse 교환 상태 기본값 Pending으로 

### DIFF
--- a/bookhouse/src/main/java/kr/co/readingtown/bookhouse/domain/Bookhouse.java
+++ b/bookhouse/src/main/java/kr/co/readingtown/bookhouse/domain/Bookhouse.java
@@ -37,7 +37,6 @@ public class Bookhouse extends BaseEntity {
         this.bookId = bookId;
         this.isExchanged = isExchanged;
         this.chatroomId = chatroomId;
-        this.isExchanged = IsExchanged.PENDING;
     }
 
     public void updateIsExchanged(IsExchanged isExchanged) {

--- a/bookhouse/src/main/java/kr/co/readingtown/bookhouse/service/BookhouseService.java
+++ b/bookhouse/src/main/java/kr/co/readingtown/bookhouse/service/BookhouseService.java
@@ -38,6 +38,7 @@ public class BookhouseService {
         Bookhouse newBookhouse = Bookhouse.builder()
                 .memberId(memberId)
                 .bookId(bookId)
+                .isExchanged(IsExchanged.PENDING)
                 .build();
         bookhouseRepository.save(newBookhouse);
     }


### PR DESCRIPTION
## ✨ Issue Number
> close #이슈번호

## 📄 작업 내용 (주요 변경 사항)

- isExchanged 필드가 nullable = false 라서  기본값 추가했습니다

## 💬 리뷰 요구사항

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 북하우스에 책을 추가할 때 교환 상태가 기본값 ‘대기(PENDING)’로 설정되어 저장됩니다.
  * 교환 상태 필드가 도입되어 새로 등록된 항목의 상태 표시가 보다 일관적입니다.
  * 목록 및 상세 화면에서 신규 항목의 초기 상태가 ‘대기’로 표시될 수 있습니다.
  * 기존 조회 및 교환 흐름에는 변화가 없으며, 사용 경험은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->