### PR TITLE
fix: 서재 책 리스트 조회 API 응답 bookhouseId 추가

### DIFF
--- a/bookhouse/src/main/java/kr/co/readingtown/bookhouse/dto/response/BookPreviewResponseDto.java
+++ b/bookhouse/src/main/java/kr/co/readingtown/bookhouse/dto/response/BookPreviewResponseDto.java
@@ -1,6 +1,7 @@
 package kr.co.readingtown.bookhouse.dto.response;
 
 public record BookPreviewResponseDto(
+        Long bookhouseId,
         Long bookId,
         String bookImage,
         String bookName,

--- a/bookhouse/src/main/java/kr/co/readingtown/bookhouse/service/BookhouseService.java
+++ b/bookhouse/src/main/java/kr/co/readingtown/bookhouse/service/BookhouseService.java
@@ -61,7 +61,24 @@ public class BookhouseService {
                 .map(Bookhouse::getBookId)
                 .toList();
 
-        List<BookPreviewResponseDto> content = bookReader.getBookInfo(bookIds);
+        List<BookPreviewResponseDto> bookInfoList = bookReader.getBookInfo(bookIds);
+        
+        // bookhouseId를 포함한 새로운 리스트 생성
+        List<BookPreviewResponseDto> content = new ArrayList<>();
+        List<Bookhouse> bookhouseList = bookhousePage.getContent();
+        
+        for (int i = 0; i < bookhouseList.size(); i++) {
+            Bookhouse bookhouse = bookhouseList.get(i);
+            BookPreviewResponseDto bookInfo = bookInfoList.get(i);
+            
+            content.add(new BookPreviewResponseDto(
+                    bookhouse.getBookhouseId(),
+                    bookInfo.bookId(),
+                    bookInfo.bookImage(),
+                    bookInfo.bookName(),
+                    bookInfo.author()
+            ));
+        }
 
         return PageResponse.of(content, bookhousePage);
     }


### PR DESCRIPTION
## ✨ Issue Number
> close #105 

## 📄 작업 내용 (주요 변경 사항)
채팅룸 생성, 교환 요청 API 요청에 필요한 bookhouseId를 서재 리스트 조회 API 응답에 추가하였습니다.

## 💬 리뷰 요구사항

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 도서 미리보기 응답에 북하우스 ID가 추가되어, 각 도서가 속한 북하우스를 식별할 수 있습니다. 목록/상세 이동 및 컨텍스트 제공이 더 명확해집니다.
* 변경 사항
  * 도서 미리보기 API 응답 필드 구성이 확장되었습니다. 기존 필드는 유지되며, 새로운 식별자 필드가 선두에 포함됩니다. 클라이언트에서 필드 순서나 매핑을 사용하는 경우 업데이트가 필요할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->