### PR TITLE
feat: 채팅 메시지 DB에 저장

### DIFF
--- a/chat/src/main/java/kr/co/readingtown/chat/service/ChatService.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/service/ChatService.java
@@ -189,4 +189,16 @@ public class ChatService {
         // Bookhouse 서비스에 교환 반납 요청 (두 Bookhouse 모두 PENDING으로 변경)
         bookhouseUpdater.returnExchange(chatroomId);
     }
+
+    // 채팅 메시지 저장
+    @Transactional
+    public void saveChatMessage(Long senderId, String roomId, String content) {
+
+        Message message = Message.builder()
+                .chatroomId(Long.parseLong(roomId))
+                .senderId(senderId)
+                .content(content)
+                .build();
+        messageRepository.save(message);
+    }
 }


### PR DESCRIPTION
## ✨ Issue Number
> close #72 

## 📄 작업 내용 (주요 변경 사항)

- SocketHandler에서 백으로 메시지 오면 '보낸 사람'과 '채팅룸 id' 파싱해서 DB에 메시지 저장하도록 구현

## 💬 리뷰 요구사항

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 채팅 메시지가 발신자 정보와 함께 구조화된 형식으로 전송되어 대화 참여자 식별이 더 명확해졌습니다.
  * 메시지가 서버에 저장된 뒤 전송되어 일시적인 연결 문제 시에도 대화 내용 유실 가능성이 줄어 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->