### PR TITLE
chore: 서버 시간대 KST 설정

### DIFF
--- a/api/src/main/java/kr/co/readingtown/BackendApplication.java
+++ b/api/src/main/java/kr/co/readingtown/BackendApplication.java
@@ -1,13 +1,21 @@
 package kr.co.readingtown;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.util.TimeZone;
 
 @SpringBootApplication
 public class BackendApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(BackendApplication.class, args);
+    }
+
+    @PostConstruct
+    public void init() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
     }
 
 }

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -10,6 +10,7 @@ spring:
   jackson:
     serialization:
       fail-on-empty-beans: false
+    time-zone: Asia/Seoul
 
 server:
   base-uri: ${SERVER_URI}


### PR DESCRIPTION
## ✨ Issue Number
> close #128 

## 📄 작업 내용 (주요 변경 사항)
- JVM 기본 시간대를 Asia/Seoul로 설정. EC2 docker-compose yml파일에도 TZ=Asia/Seoul 추가
- 서버 시작마다 보이는 s3 version1 경고 문구 안 보이게 환경변수에 DISABLE_DEPRECATION_ANNOUNCEMENT=true 추가했습니다.

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 기본 시간대를 Asia/Seoul로 설정하도록 애플리케이션 초기화 구성을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->