### PR TITLE
chore: AWS SDK JMX 메트릭 비활성화로 JDK cgroup NullPointerException 해결

### DIFF
--- a/common/src/main/java/kr/co/readingtown/common/config/S3Config.java
+++ b/common/src/main/java/kr/co/readingtown/common/config/S3Config.java
@@ -2,8 +2,10 @@ package kr.co.readingtown.common.config;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.metrics.AwsSdkMetrics;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,6 +21,21 @@ public class S3Config {
 
     @Value("${aws.s3.region}")
     private String region;
+
+    // 애플리케이션 시작 시 AWS SDK의 JMX/metrics 등록을 비활성화
+    @PostConstruct
+    public void disableAwsSdkJmx() {
+        try {
+            // JVM의 컨테이너 감지 비활성화
+            System.setProperty("jdk.internal.platform.disableContainerSupport", "true");
+
+            // AWS SDK의 JMX MBean 등록 비활성화
+            AwsSdkMetrics.unregisterMetricAdminMBean();
+
+        } catch (Throwable ignored) {
+            // 에러 무시 (JMX 비활성화만 목적)
+        }
+    }
 
     @Bean
     public AmazonS3 getAmazonS3Client() {


### PR DESCRIPTION
## ✨ Issue Number
> close #이슈번호

## 📄 작업 내용 (주요 변경 사항)
- 기존 환경변수 설정으로는 수정이 안돼서 추가했습니다.
- AWS SDK 초기화 시 JMX MBean 등록 과정에서 jdk.internal.platform.CgroupInfo.getMountPoint() 호출로 인한 NPE가 발생하던 문제 해결
- S3Config AwsSdkMetrics.unregisterMetricAdminMBean() 호출을 추가하여 컨테이너 환경에서 불필요한 시스템 메트릭 등록을 비활성화

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * AWS SDK 메트릭 등록 비활성화로 애플리케이션 성능 최적화를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->