### PR TITLE
chore: swagger 파일명 중복 오류 임시 처리

### DIFF
--- a/bookhouse/src/main/java/kr/co/readingtown/bookhouse/externalapi/ExternalBookhouseController.java
+++ b/bookhouse/src/main/java/kr/co/readingtown/bookhouse/externalapi/ExternalBookhouseController.java
@@ -50,7 +50,7 @@ public class ExternalBookhouseController {
     }
 
     @GetMapping("/members/me")
-    @Operation(summary = "내 서재 조회", description = "현재 로그인한 회원의 서재를 조회합니다.")
+    @Operation(summary = "내 서재 조회(믿지마셈)", description = "현재 로그인한 회원의 서재를 조회합니다.")
     public PageResponse<BookPreviewResponseDto> getMyBookhouse(
             @AuthenticationPrincipal Long memberId,
             @RequestParam(defaultValue = "0") int page,
@@ -60,7 +60,7 @@ public class ExternalBookhouseController {
     }
 
     @GetMapping("/members/{memberId}")
-    @Operation(summary = "회원의 서재 조회", description = "특정 회원의 서재를 조회합니다.")
+    @Operation(summary = "회원의 서재 조회(믿지마셈)", description = "특정 회원의 서재를 조회합니다.")
     public PageResponse<BookPreviewResponseDto> getBookhouseByMemberId(
             @PathVariable Long memberId,
             @RequestParam(defaultValue = "0") int page,


### PR DESCRIPTION
## ✨ Issue Number
> close #아직

## 📄 작업 내용 (주요 변경 사항)
- swgger respone 응답 값이 코드와 다르게 나오는 오류를 확인했는데, swagger가 응답 DTO를 다른 모듈의 중복된 이름의 DTO 파일로 착각하고있어 발생하는 것으로 파악하였습니다. 
- bookhouse의 BookPreviewResponseDto과 book의 BookPreviewResponseDto가 중복 
- internal 응답과도 파일들이 엮어있어서 프론트 헷갈리지 않게 설명만 수정하고 추후 수정할 예정입니다.

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 북하우스 API 엔드포인트의 작동 요약 정보가 업데이트되었습니다. 기능적 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->