### PR TITLE
fix: 채팅 내 교환요청한 책 정보 조회 시 로그인 사용자 기준으로 mybook으로 매칭되게 수정

### DIFF
--- a/bookhouse/src/main/java/kr/co/readingtown/bookhouse/internalapi/InternalExchangeStatusController.java
+++ b/bookhouse/src/main/java/kr/co/readingtown/bookhouse/internalapi/InternalExchangeStatusController.java
@@ -21,7 +21,7 @@ public class InternalExchangeStatusController {
     @GetMapping("/internal/exchange-status/{chatroomId}/book")
     public ExchangedBookResponse getBookIdByChatroomId(
             @PathVariable Long chatroomId,
-            @AuthenticationPrincipal Long myId) {
+            @RequestParam Long myId) {
 
         return exchangeStatusService.getBookIdByChatroomId(chatroomId, myId);
     }

--- a/bookhouse/src/main/java/kr/co/readingtown/bookhouse/service/ExchangeStatusService.java
+++ b/bookhouse/src/main/java/kr/co/readingtown/bookhouse/service/ExchangeStatusService.java
@@ -29,6 +29,7 @@ public class ExchangeStatusService {
     private final ChatClient chatClient;
     private final BookhouseService bookhouseService;
 
+    // 채팅방 내 교환요청한 책 정보 조회
     public ExchangedBookResponse getBookIdByChatroomId(Long chatroomId, Long myId) {
 
         List<ExchangeStatus> exchangeStatusList = exchangeStatusRepository.findByChatroomId(chatroomId);

--- a/chat/src/main/java/kr/co/readingtown/chat/externalapi/ExternalChatController.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/externalapi/ExternalChatController.java
@@ -31,9 +31,11 @@ public class ExternalChatController {
 
     @GetMapping("/{chatroomId}/books")
     @Operation(summary = "교환 책 정보 조회", description = "채팅 페이지에서 교환 책 정보를 조회하는 API 입니다.")
-    public ChatExchangedBookInfoResponse getExchangedBookInfo(@PathVariable Long chatroomId) {
+    public ChatExchangedBookInfoResponse getExchangedBookInfo(
+            @PathVariable Long chatroomId,
+            @AuthenticationPrincipal Long myId) {
 
-        return chatService.getExchangedBookInfo(chatroomId);
+        return chatService.getExchangedBookInfo(chatroomId, myId);
     }
 
     @GetMapping("/{chatroomId}/partner/profile")

--- a/chat/src/main/java/kr/co/readingtown/chat/integration/bookhouse/BookhouseClient.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/integration/bookhouse/BookhouseClient.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 public interface BookhouseClient {
 
     @GetMapping("/internal/exchange-status/{chatroomId}/book")
-    ExchangedBookResponse getBookIdByChatroomId(@PathVariable Long chatroomId);
+    ExchangedBookResponse getBookIdByChatroomId(@PathVariable Long chatroomId, @RequestParam Long myId);
 
     @GetMapping("/internal/chatrooms/{chatroomId}/exchange-status")
     Boolean isExchanging(@PathVariable Long chatroomId);

--- a/chat/src/main/java/kr/co/readingtown/chat/service/ChatService.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/service/ChatService.java
@@ -64,9 +64,9 @@ public class ChatService {
     }
 
     // 채팅룸 교환 책 정보 조회
-    public ChatExchangedBookInfoResponse getExchangedBookInfo(Long chatroomId) {
+    public ChatExchangedBookInfoResponse getExchangedBookInfo(Long chatroomId, Long myId) {
 
-        ExchangedBookResponse exchangedBooks = bookhouseClient.getBookIdByChatroomId(chatroomId);
+        ExchangedBookResponse exchangedBooks = bookhouseClient.getBookIdByChatroomId(chatroomId, myId);
 
         BookInfoResponse myBookInfo = null;
         BookInfoResponse partnerBookInfo = null;


### PR DESCRIPTION
## ✨ Issue Number
> close #165 

## 📄 작업 내용 (주요 변경 사항)
 
### 문제 상황
  - GET /api/v1/chatrooms/{chatroomId}/books API 호출 시, 현재 사용자 기준으로 myBook과 partnerBook이 올바르게 구분되지 않는 문제

  - 원인: myId 파라미터가 Controller → Service → FeignClient → Bookhouse Service 체인에서 전달되지 않음

 ### 해결 방법
  - myId 파라미터를 전체 호출 체인에 추가하여 ExchangeStatusService에서 책 소유자를 올바르게 구분할 수 있도록 수정하여 API 호출한 사용자 기준으로 myBook과 partnerBook이 올바르게 구분

- 최종 myId 전달 체인

  1. ExternalChatController
     @AuthenticationPrincipal Long myId
     ↓

  2. ChatService
     getExchangedBookInfo(chatroomId, myId)
     ↓

  3. BookhouseClient (FeignClient)
     @RequestParam Long myId
     ↓

  4. InternalExchangeStatusController
     @RequestParam Long myId
     ↓

  5. ExchangeStatusService
     getBookIdByChatroomId(chatroomId, myId)
     ↓
     if (bookhouse.getMemberId().equals(myId))
         → myBook (내 책)
     else
         → partnerBook (상대방 책)

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 책 교환 정보 조회 프로세스의 내부 구조를 개선하여 사용자 식별 메커니즘을 명시적으로 처리하도록 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->