### PR TITLE
fix: MessageType에 교환 취소 전용 enum 추가

### DIFF
--- a/bookhouse/src/main/java/kr/co/readingtown/bookhouse/service/ExchangeStatusService.java
+++ b/bookhouse/src/main/java/kr/co/readingtown/bookhouse/service/ExchangeStatusService.java
@@ -248,7 +248,7 @@ public class ExchangeStatusService {
                     exchangeStatus.getChatroomId(),
                     memberId,  // 취소한 사람의 ID
                     "교환 신청이 취소되었습니다.",
-                    "SYSTEM",  // 취소는 일반 시스템 메시지로
+                    "EXCHANGE_CANCELED",  // 교환 취소 메시지 타입
                     exchangeStatus.getExchangeStatusId()
             );
             chatClient.sendSystemMessage(messageDto);

--- a/chat/src/main/java/kr/co/readingtown/chat/domain/MessageType.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/domain/MessageType.java
@@ -5,6 +5,7 @@ public enum MessageType {
     EXCHANGE_REQUEST,   // 교환 신청
     EXCHANGE_ACCEPTED,  // 교환 수락
     EXCHANGE_REJECTED,  // 교환 거절
+    EXCHANGE_CANCELED,  // 교환 취소
     EXCHANGE_RESERVED,  // 예약 완료
     EXCHANGE_COMPLETED, // 교환 완료
     EXCHANGE_RETURNED,  // 반납 완료


### PR DESCRIPTION
## ✨ Issue Number
> close #168 

## 📄 작업 내용 (주요 변경 사항)
MessageType enum : SYSTEM -> Exchanged_CANCELED 으로 명시화

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 환전 취소 알림의 메시지 분류 체계를 개선하여 더 정확한 상태 구분을 제공합니다. 취소된 환전 거래에 대한 알림이 명확하게 식별되도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->