### PR TITLE
fix: 채팅룸 교환 책 정보 API isAccepted 값에 모든 책 상태 추가

### DIFF
--- a/bookhouse/src/main/java/kr/co/readingtown/bookhouse/internalapi/InternalExchangeStatusController.java
+++ b/bookhouse/src/main/java/kr/co/readingtown/bookhouse/internalapi/InternalExchangeStatusController.java
@@ -6,7 +6,6 @@ import kr.co.readingtown.bookhouse.dto.response.ExchangingBookResponse;
 import kr.co.readingtown.bookhouse.service.BookhouseService;
 import kr.co.readingtown.bookhouse.service.ExchangeStatusService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,16 +18,13 @@ public class InternalExchangeStatusController {
     private final BookhouseService bookhouseService;
 
     @GetMapping("/internal/exchange-status/{chatroomId}/book")
-    public ExchangedBookResponse getBookIdByChatroomId(
-            @PathVariable Long chatroomId,
-            @RequestParam Long myId) {
+    public ExchangedBookResponse getBookIdByChatroomId(@PathVariable Long chatroomId, @RequestParam Long myId) {
 
         return exchangeStatusService.getBookIdByChatroomId(chatroomId, myId);
     }
 
     @GetMapping("/internal/chatrooms/{chatroomId}/status")
-    public ExchangeStatusResponse getExchangeStatus(
-            @PathVariable Long chatroomId) {
+    public ExchangeStatusResponse getExchangeStatus(@PathVariable Long chatroomId) {
 
         return exchangeStatusService.getExchangeStatus(chatroomId);
     }

--- a/bookhouse/src/main/java/kr/co/readingtown/bookhouse/service/ExchangeStatusService.java
+++ b/bookhouse/src/main/java/kr/co/readingtown/bookhouse/service/ExchangeStatusService.java
@@ -29,7 +29,7 @@ public class ExchangeStatusService {
     private final ChatClient chatClient;
     private final BookhouseService bookhouseService;
 
-    // 채팅방 내 교환요청한 책 정보 조회
+    // 채팅방 내 교환 요청한 책 정보 조회
     public ExchangedBookResponse getBookIdByChatroomId(Long chatroomId, Long myId) {
 
         List<ExchangeStatus> exchangeStatusList = exchangeStatusRepository.findByChatroomId(chatroomId);
@@ -41,19 +41,26 @@ public class ExchangeStatusService {
             Bookhouse bookhouse = bookhouseRepository.findById(status.getBookhouseId())
                     .orElseThrow(BookhouseException.BookhouseNotFound::new);
 
+            // 교환 확정 이후 (RESERVED, EXCHANGED) → isExchanged 상태 반환
+            // 교환 요청 단계 (PENDING) → requestStatus 상태 반환
+            String statusValue = (bookhouse.getIsExchanged() == IsExchanged.RESERVED ||
+                                  bookhouse.getIsExchanged() == IsExchanged.EXCHANGED)
+                    ? bookhouse.getIsExchanged().toString()
+                    : status.getRequestStatus().toString();
+
             if (bookhouse.getMemberId().equals(myId)) {
                 myBook = new ExchangedDetail(
                         status.getExchangeStatusId(),
                         bookhouse.getBookhouseId(),
                         bookhouse.getBookId(),
-                        bookhouse.getIsExchanged().toString()
+                        statusValue
                 );
             } else {
                 partnerBook = new ExchangedDetail(
                         status.getExchangeStatusId(),
                         bookhouse.getBookhouseId(),
                         bookhouse.getBookId(),
-                        bookhouse.getIsExchanged().toString()
+                        statusValue
                 );
             }
         }


### PR DESCRIPTION
## ✨ Issue Number
> close #172 

## 📄 작업 내용 (주요 변경 사항)
기존 코드는 isAccepted가 bookhouse의 상태만 반환하고 있어, 프론트에 'PENDING'만 반환되던 상황. 
- 교환 요청 단계 (PENDING)는 → ExchangeRequest 엔티티의 requestStatus 상태 반환
- 교환 확정 이후 (RESERVED, EXCHANGED)는 → bookhouse 엔티티의 isExchanged 상태 반환
하게 수정

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 도서 교환 상태 표시 로직을 개선하여 예약 또는 교환된 상태의 도서는 해당 상태를 정확히 반영하고, 그 외의 경우 요청의 현재 상태를 올바르게 표시하도록 수정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->