### PR TITLE
fix: 대면 교환 완료, 반납 시 상태 확인 exception 오류

### DIFF
--- a/bookhouse/src/main/java/kr/co/readingtown/bookhouse/repository/BookhouseRepository.java
+++ b/bookhouse/src/main/java/kr/co/readingtown/bookhouse/repository/BookhouseRepository.java
@@ -27,6 +27,10 @@ public interface BookhouseRepository extends JpaRepository<Bookhouse, Long> {
     List<Bookhouse> findAllByChatroomId(Long chatroomId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT b FROM Bookhouse b WHERE b.chatroomId = :chatroomId")
+    List<Bookhouse> findAllByChatroomIdForUpdate(@Param("chatroomId") Long chatroomId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select b from Bookhouse b where b.bookhouseId in :bookhouseIds")
     List<Bookhouse> findAllByIdForUpdate(@Param("bookhouseIds")List<Long> bookhouseIds);
 

--- a/bookhouse/src/main/java/kr/co/readingtown/bookhouse/service/ExchangeStatusService.java
+++ b/bookhouse/src/main/java/kr/co/readingtown/bookhouse/service/ExchangeStatusService.java
@@ -269,8 +269,8 @@ public class ExchangeStatusService {
     // 교환 시작 - RESERVED -> EXCHANGED
     @Transactional
     public void completeExchange(Long chatroomId) {
-        // chatroomId로 Bookhouse 조회
-        List<Bookhouse> books = bookhouseRepository.findAllByChatroomId(chatroomId);
+        // chatroomId로 Bookhouse 조회 (동시성 제어를 위한 행 잠금)
+        List<Bookhouse> books = bookhouseRepository.findAllByChatroomIdForUpdate(chatroomId);
 
         // Bookhouse가 정확히 2개인지 확인
         if (books.size() != 2) {
@@ -305,8 +305,8 @@ public class ExchangeStatusService {
     // 교환 반납 - EXCHANGED -> PENDING
     @Transactional
     public void returnExchange(Long chatroomId) {
-        // chatroomId로 Bookhouse 조회
-        List<Bookhouse> books = bookhouseRepository.findAllByChatroomId(chatroomId);
+        // chatroomId로 Bookhouse 조회 (동시성 제어를 위한 행 잠금)
+        List<Bookhouse> books = bookhouseRepository.findAllByChatroomIdForUpdate(chatroomId);
 
         // Bookhouse가 정확히 2개인지 확인
         if (books.size() != 2) {


### PR DESCRIPTION
## ✨ Issue Number
> close #

## 📄 작업 내용 (주요 변경 사항)
문제 : 대면 교환 완료 요청시, "채팅 방 내 생성된 교환 요청 개수가 2개가 아닙니다" exception이 bookhouse의 상태가 아닌, exchangeRequest의 상태로 잘못 계산되는 로직이었음
 
해결 : 
- 모두 bookhouse 엔티티의 isExchanged를 보고 
- 완료할 때는 해당 채팅방 id의 책들이 모두 reserved인지 확인, 반납 시에는 모두 Exchanged인지 확인하게 수정
- 대면 교환 완료와 대면 교환 반납 모두 사용자 한 명만 요청하면 두 책 모두 바뀜.
- 반납 시 bookhouse의 chatroomId도 삭제됨
- 하나의 채팅방에는 하나의 교환만 가능하다는 전제(새로운 교환은 새로운 채팅방 또 생성)

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 책 교환 프로세스의 데이터 검증 강화 — 채팅방당 관련 도서가 정확히 두 건인지 사전 확인
  * 상태 전이 검증 추가 — 교환 완료 시 예약(RESERVED) 확인, 반품 시 교환(EXCHANGED) 확인
  * 동시성 처리 강화로 상태 업데이트 안정성 향상(잠금 기반 동시성 제어 적용)
  * 시스템 메시지 내용 및 유형 일부 조정으로 흐름 유지 및 명확성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->