### PR TITLE
chore: 로그인 세션 만료 테스트용 accessToken 시간 30초로 수정

### DIFF
--- a/authentication/src/main/java/kr/co/readingtown/authentication/jwt/TokenProvider.java
+++ b/authentication/src/main/java/kr/co/readingtown/authentication/jwt/TokenProvider.java
@@ -25,7 +25,7 @@ public class TokenProvider {
     public static final String ACCESS_TOKEN_TYPE = "access";
 
     public static final String REFRESH_TOKEN_TYPE = "refresh";
-    private final long accessTokenValidityInMillis = 1000 * 60 * 15; // 15분
+    private final long accessTokenValidityInMillis = 1000 * 30; // 30초
     private final long refreshTokenValidityInMillis = 1000L * 60 * 60 * 24 * 7; // 일주일
 
     @PostConstruct


### PR DESCRIPTION
## ✨ Issue Number
> close #183 

## 📄 작업 내용 (주요 변경 사항)
15분마다 로그인 세션 만료로 강제로그아웃되는데 프론트에서 테스트해보고싶다하여 accessToken 시간 30초로 수정

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **보안**
  * 액세스 토큰 유효 기간을 15분에서 30초로 단축하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->