### PR TITLE
fix: internal과 external dto 필드명 통일

### DIFF
--- a/member/src/main/java/kr/co/readingtown/member/dto/response/internal/ExchangingBookResponseDto.java
+++ b/member/src/main/java/kr/co/readingtown/member/dto/response/internal/ExchangingBookResponseDto.java
@@ -1,9 +1,9 @@
 package kr.co.readingtown.member.dto.response.internal;
 
 public record ExchangingBookResponseDto(
-        Long chatRoomId,
+        Long chatroomId,
         ExchangingBookDetail myBook,
-        ExchangingBookDetail yourBook
+        ExchangingBookDetail partnerBook
 ) {
     public record ExchangingBookDetail(
             Long bookhouseId,


### PR DESCRIPTION
## ✨ Issue Number
> close #204 

## 📄 작업 내용 (주요 변경 사항)
external 로 받는 dto 필드명이 달라서 해당 부분은 null로 오는 문제 해결

## 💬 리뷰 요구사항

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **주요 변경사항**
  * API 응답 필드명 업데이트: `chatRoomId` → `chatroomId`, `yourBook` → `partnerBook`로 변경되었습니다. 데이터 교환 기능을 사용하는 경우 응답 형식 변경사항을 확인해 주시기 바랍니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->