### PR TITLE
chore: accessToken과 cookie 설정 시간 15분 설정

### DIFF
--- a/authentication/src/main/java/kr/co/readingtown/authentication/jwt/TokenProvider.java
+++ b/authentication/src/main/java/kr/co/readingtown/authentication/jwt/TokenProvider.java
@@ -25,7 +25,7 @@ public class TokenProvider {
     public static final String ACCESS_TOKEN_TYPE = "access";
 
     public static final String REFRESH_TOKEN_TYPE = "refresh";
-    private final long accessTokenValidityInMillis = 1000 * 30; // 30초
+    private final long accessTokenValidityInMillis = 1000L * 60 * 15; // 15분
     private final long refreshTokenValidityInMillis = 1000L * 60 * 60 * 24 * 7; // 일주일
 
     @PostConstruct

--- a/common/src/main/java/kr/co/readingtown/common/util/CookieUtil.java
+++ b/common/src/main/java/kr/co/readingtown/common/util/CookieUtil.java
@@ -38,7 +38,7 @@ public class CookieUtil {
                 .secure(true)
                 .path("/")
                 .sameSite("None")
-                .maxAge(Duration.ofSeconds(30))
+                .maxAge(Duration.ofMinutes(15))
                 .build();
 
         // refreshToken 쿠키 설정


### PR DESCRIPTION
## ✨ Issue Number
> close #183 

## 📄 작업 내용 (주요 변경 사항)
accessToken Reissue 성공으로 다시 15분으로 되돌려두기

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 액세스 토큰 유효 기간을 30초에서 15분으로 연장하여 세션 유지 시간 개선

* **개선 사항**
  * 인증 토큰의 만료 시간 정책을 조정하여 사용자 경험 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->