### PR TITLE
fix: WebSocket URL의 쿼리 스트링 전체를 읽어서 직접 파싱

### DIFF
--- a/chat/src/main/java/kr/co/readingtown/chat/handler/JwtHandshakeInterceptor.java
+++ b/chat/src/main/java/kr/co/readingtown/chat/handler/JwtHandshakeInterceptor.java
@@ -55,8 +55,14 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
         if (request instanceof ServletServerHttpRequest servletRequest) {
             HttpServletRequest httpRequest = servletRequest.getServletRequest();
 
-            String roomId = httpRequest.getParameter("roomId");
-            attributes.put("roomId", roomId);
+            // WebSocket 쿼리 파라미터에서 roomId 추출
+            String query = request.getURI().getQuery();
+            if (query != null) {
+                String roomId = extractQueryParam(query, "roomId");
+                if (roomId != null && !roomId.isEmpty()) {
+                    attributes.put("roomId", roomId);
+                }
+            }
 
             String token = cookieUtil.extractTokenFromCookie(httpRequest, ACCESS_TOKEN_COOKIE_NAME);
 
@@ -84,5 +90,24 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
                                ServerHttpResponse response,
                                WebSocketHandler wsHandler,
                                Exception exception) {
+    }
+
+    /**
+     * 쿼리 스트링에서 특정 파라미터 값 추출
+     * 예: "roomId=123&other=value" -> "123"
+     */
+    private String extractQueryParam(String query, String paramName) {
+        if (query == null || query.isEmpty()) {
+            return null;
+        }
+
+        String[] params = query.split("&");
+        for (String param : params) {
+            String[] keyValue = param.split("=");
+            if (keyValue.length == 2 && keyValue[0].equals(paramName)) {
+                return keyValue[1];
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## ✨ Issue Number
> close #207

## 📄 작업 내용 (주요 변경 사항)
- http 방식의 파라미터 추출 방식 작동x

## 💬 리뷰 요구사항

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * WebSocket 연결 중 채팅방 식별자 추출 방식을 개선하여 연결 안정성을 향상했습니다.

* **리팩토링**
  * 쿼리 파라미터 추출 로직을 최적화하고 유효성 검사를 강화하여 연결 신뢰성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->