### PR TITLE
fix: exception 대신 null 반환

### DIFF
--- a/review/src/main/java/kr/co/readingtown/review/service/ReviewService.java
+++ b/review/src/main/java/kr/co/readingtown/review/service/ReviewService.java
@@ -70,10 +70,9 @@ public class ReviewService {
         bookValidator.validateBookExists(bookId);
         memberValidator.validateMemberExists(memberId);
 
-        ReviewIdAndContentDto myReview = reviewRepository.findReviewByBookIdAndMemberId(bookId, memberId)
-                .orElseThrow(ReviewException.ReviewNotFound::new);
-
-        return ReviewResponseDto.toReviewResponseDto(myReview);
+        return reviewRepository.findReviewByBookIdAndMemberId(bookId, memberId)
+                .map(ReviewResponseDto::toReviewResponseDto)
+                .orElse(null);
     }
 
     // 특정 책의 모든 감상평 조회 (자기 자신 제외)


### PR DESCRIPTION
## ✨ Issue Number
> close #217 

## 📄 작업 내용 (주요 변경 사항)
감상평 조회 API 에서 내 감상평이 없는 경우에 exception 대신 null 반환

## 💬 리뷰 요구사항

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 리뷰를 찾을 수 없는 경우 예외 발생 대신 null을 반환하도록 변경하여 리뷰 조회 동작을 개선했습니다. 이제 존재하지 않는 리뷰에 대한 처리가 더욱 안정적으로 진행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->