### PR TITLE
fix: member 생성 시 이미지 설정, 기본 이미지 경로에 맞는 이미지 수정 로직

### DIFF
--- a/member/src/main/java/kr/co/readingtown/member/service/MemberService.java
+++ b/member/src/main/java/kr/co/readingtown/member/service/MemberService.java
@@ -46,6 +46,7 @@ public class MemberService {
                     .loginId(loginId)
                     .username(username)
                     .nickname(null) //기본 닉네임 Null로 설정 후 온보딩에서 설정
+                    .profileImage(appProperties.getDefaultProfileImageUrl())
                     .userRatingSum(0)
                     .userRatingCount(0)
                     .build();
@@ -450,12 +451,12 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(MemberException.NoAuthMember::new);
 
-        // key 조회
-        String oldKey = imageService.urlToKey(member.getProfileImage());
+        // 새 key 생성
         String newKey = "profile/" + memberId + "_" + UUID.randomUUID() + ".png";
 
-        // oldKey가 default가 아니라면 삭제
-        if (oldKey.equals("readingtown_profile_gray.png")) {
+        // 기존 이미지가 사용자가 업로드한 이미지라면 삭제 (profile/로 시작하는 경우만)
+        String oldKey = imageService.urlToKey(member.getProfileImage());
+        if (oldKey != null && oldKey.startsWith("profile/")) {
             imageService.deleteImage(oldKey);
         }
 


### PR DESCRIPTION
## ✨ Issue Number
> close #220 

## 📄 작업 내용 (주요 변경 사항)
- /profile 에 default-image가 위치한다고 생각하고 기존 이미지를 삭제해서 s3에 기본 이미지 파일이 삭제되는 오류를 수정했습니다.
- 온보딩에서 프로필 이미지 수정 시 Cannot invoke "String.equals(Object)" because "oldKey" is null 오류를 막기위해 온보딩 전에 member를 생성할 때 기본 이미지를 가지도록 수정했습니다.

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 회원 가입 시 기본 프로필 이미지 할당 로직 개선
  * 프로필 이미지 변경 시 이전 이미지 정리 프로세스 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->