### PR TITLE
fix: 특정 책을 가진 서재 리스트에 로그인한 사용자 본인은 제외

### DIFF
--- a/bookhouse/src/main/java/kr/co/readingtown/bookhouse/service/BookhouseService.java
+++ b/bookhouse/src/main/java/kr/co/readingtown/bookhouse/service/BookhouseService.java
@@ -191,6 +191,13 @@ public class BookhouseService {
     public List<BookhouseOwnerResponseDto> getBookhousesByBookId(Long bookId, Long currentMemberId) {
         List<Bookhouse> bookhouses = bookhouseRepository.findAllByBookIdOrderByCreatedAtDesc(bookId);
 
+        // 로그인한 사용자 본인은 제외
+        if (currentMemberId != null) {
+            bookhouses = bookhouses.stream()
+                    .filter(bh -> !bh.getMemberId().equals(currentMemberId))
+                    .toList();
+        }
+
         if (bookhouses.isEmpty()) {
             return List.of();
         }
@@ -230,6 +237,7 @@ public class BookhouseService {
 
         return responses;
     }
+
     // 유저가 서재에 가지고있는 책의 id 조회
     public List<Long> getMembersBookId(Long memberId) {
         return bookhouseRepository.findBookIdByMember(memberId);


### PR DESCRIPTION
## ✨ Issue Number
> close #222 

## 📄 작업 내용 (주요 변경 사항)
특정 책을 가진 서재 리스트 조회 API 에 로그인한 사용자 본인은 제외하고 반환

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 현재 로그인한 사용자의 서재가 목록 조회 시 제외됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->