### PR TITLE
fix: ExchangeStatus 교환 수락 데드락 수정 및 리팩토링

### DIFF
--- a/bookhouse/src/main/java/kr/co/readingtown/bookhouse/repository/ExchangeStatusRepository.java
+++ b/bookhouse/src/main/java/kr/co/readingtown/bookhouse/repository/ExchangeStatusRepository.java
@@ -25,6 +25,9 @@ public interface ExchangeStatusRepository extends JpaRepository<ExchangeStatus, 
     """)
     List<ExchangeStatus> findAllByChatroomIdForUpdate(@Param("chatroomId") Long chatroomId);
 
+    @Query("select e.chatroomId from ExchangeStatus e where e.exchangeStatusId = :exchangeStatusId")
+    Long findChatroomIdById(@Param("exchangeStatusId") Long exchangeStatusId);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select e from ExchangeStatus e where e.exchangeStatusId = :exchangeStatusId")
     Optional<ExchangeStatus> findByIdForUpdate(@Param("exchangeStatusId") Long id);

--- a/bookhouse/src/main/java/kr/co/readingtown/bookhouse/service/ExchangeStatusService.java
+++ b/bookhouse/src/main/java/kr/co/readingtown/bookhouse/service/ExchangeStatusService.java
@@ -107,90 +107,88 @@ public class ExchangeStatusService {
     // 교환 요청 수락
     @Transactional
     public AcceptExchangeResponseDto acceptExchangeStatus(Long memberId, Long exchangeStatusId) {
+        List<ExchangeStatus> allInRoom = lockChatroomAndGetAll(exchangeStatusId);
+        ExchangeStatus exchangeStatus = findFromLocked(allInRoom, exchangeStatusId);
 
-        ExchangeStatus exchangeStatus = exchangeStatusRepository.findByIdForUpdate(exchangeStatusId)
+        validateAcceptPermission(exchangeStatus, memberId);
+        exchangeStatus.updateRequestStatus(RequestStatus.ACCEPTED);
+
+        boolean reserved = tryReserve(allInRoom, exchangeStatus);
+        sendAcceptMessage(exchangeStatus, memberId, reserved);
+
+        return new AcceptExchangeResponseDto(exchangeStatus.getRequestStatus(), reserved);
+    }
+
+    // 채팅방 전체 행 락 획득
+    private List<ExchangeStatus> lockChatroomAndGetAll(Long exchangeStatusId) {
+        Long chatroomId = exchangeStatusRepository.findChatroomIdById(exchangeStatusId);
+        if (chatroomId == null) throw new BookhouseException.ExchangeStatusNotFound();
+        return exchangeStatusRepository.findAllByChatroomIdForUpdate(chatroomId);
+    }
+
+    // 락 걸린 리스트에서 대상 ExchangeStatus 추출
+    private ExchangeStatus findFromLocked(List<ExchangeStatus> allInRoom, Long exchangeStatusId) {
+        return allInRoom.stream()
+                .filter(e -> e.getExchangeStatusId().equals(exchangeStatusId))
+                .findFirst()
                 .orElseThrow(BookhouseException.ExchangeStatusNotFound::new);
+    }
 
+    // 소유자 및 상태 검증
+    private void validateAcceptPermission(ExchangeStatus exchangeStatus, Long memberId) {
         Bookhouse bookhouse = bookhouseRepository.findById(exchangeStatus.getBookhouseId())
                 .orElseThrow(BookhouseException.BookhouseNotFound::new);
 
-        // memberId 가 해당 bookhouse의 소유자인지 검증
         if (!bookhouse.getMemberId().equals(memberId)) {
             throw new BookhouseException.ForbiddenAcceptRequest();
         }
-
-        // 1) 채팅방의 모든 교환행을 잠금
-        List<ExchangeStatus> allInRoom = exchangeStatusRepository.findAllByChatroomIdForUpdate(exchangeStatus.getChatroomId());
-
-
-        // 2) Request 상태에서만 교환 요청 수락 가능
         if (exchangeStatus.getRequestStatus() != RequestStatus.REQUEST) {
             throw new BookhouseException.InvalidExchangeStatusForTransition();
         }
+    }
 
-        // 3) 수락으로 전환
-        exchangeStatus.updateRequestStatus(RequestStatus.ACCEPTED);
-
-        // 4) 같은 트랜잭션/잠금 하에서 메모리 상으로 ACCEPTED 개수 계산
+    // 두 명 모두 수락 시 RESERVED 전환 시도
+    private boolean tryReserve(List<ExchangeStatus> allInRoom, ExchangeStatus exchangeStatus) {
         long acceptedCount = allInRoom.stream()
-                .map(ExchangeStatus::getRequestStatus)
-                .filter(RequestStatus.ACCEPTED::equals)
+                .filter(e -> e.getRequestStatus() == RequestStatus.ACCEPTED)
                 .count();
 
-        boolean reserved = false;
+        if (acceptedCount > 2) throw new BookhouseException.DomainInvariantBroken();
+        if (acceptedCount < 2) return false;
 
-        if (acceptedCount >= 2) {
-            if (acceptedCount != 2) {
-                throw new BookhouseException.DomainInvariantBroken();
-            }
-            // 5) 두 책 예약(RESERVED) 전환 (Bookhouse도 잠금)
-            List<Long> bookhouseIds = allInRoom.stream()
-                    .filter(es -> es.getRequestStatus() == RequestStatus.ACCEPTED)
-                    .map(ExchangeStatus::getBookhouseId)
-                    .toList();
+        List<Long> bookhouseIds = allInRoom.stream()
+                .filter(es -> es.getRequestStatus() == RequestStatus.ACCEPTED)
+                .map(ExchangeStatus::getBookhouseId)
+                .toList();
 
-            List<Bookhouse> books = bookhouseRepository.findAllByIdForUpdate(bookhouseIds);
-            for (Bookhouse b : books) {
-                //이미 예약된 책에 대해 교환 수락을 시도하는 경우, 다시 REQUEST 상태로 되돌려놓음
-                if (b.getIsExchanged() == IsExchanged.RESERVED){
-                    exchangeStatus.updateRequestStatus(RequestStatus.REQUEST);
-                    throw new BookhouseException.BookAlreadyReserved();
-                }
-                b.updateIsExchanged(IsExchanged.RESERVED);
-                b.updateChatroomId(exchangeStatus.getChatroomId());
+        List<Bookhouse> books = bookhouseRepository.findAllByIdForUpdate(bookhouseIds);
+        for (Bookhouse b : books) {
+            if (b.getIsExchanged() == IsExchanged.RESERVED) {
+                exchangeStatus.updateRequestStatus(RequestStatus.REQUEST);
+                throw new BookhouseException.BookAlreadyReserved();
             }
-            reserved = true;
-            
-            // ✅ 예약 완료 시스템 메시지 전송
-            try {
-                ExchangeRequestMessageDto messageDto = new ExchangeRequestMessageDto(
-                        exchangeStatus.getChatroomId(),
-                        0L,  // 시스템 메시지 (양측 모두 수락한 경우)
-                        "교환이 예약되었습니다. 대면 교환을 진행해주세요.",
-                        "EXCHANGE_RESERVED",
-                        exchangeStatus.getExchangeStatusId()
-                );
-                chatClient.sendSystemMessage(messageDto);
-            } catch (Exception e) {
-                // 채팅 서비스 장애 시에도 교환 수락은 정상 처리
-            }
-        } else {
-            // ✅ 교환 수락 시스템 메시지 전송 (아직 한 명만 수락한 경우)
-            try {
-                ExchangeRequestMessageDto messageDto = new ExchangeRequestMessageDto(
-                        exchangeStatus.getChatroomId(),
-                        memberId,  // 수락한 사람의 ID
-                        "교환 신청이 수락되었습니다.",
-                        "EXCHANGE_ACCEPTED",
-                        exchangeStatus.getExchangeStatusId()
-                );
-                chatClient.sendSystemMessage(messageDto);
-            } catch (Exception e) {
-                // 채팅 서비스 장애 시에도 교환 수락은 정상 처리
-            }
+            b.updateIsExchanged(IsExchanged.RESERVED);
+            b.updateChatroomId(exchangeStatus.getChatroomId());
         }
+        return true;
+    }
 
-        return new AcceptExchangeResponseDto(exchangeStatus.getRequestStatus(), reserved);
+    // 수락 결과에 따른 시스템 메시지 발행
+    private void sendAcceptMessage(ExchangeStatus exchangeStatus, Long memberId, boolean reserved) {
+        try {
+            ExchangeRequestMessageDto messageDto = reserved
+                    ? new ExchangeRequestMessageDto(
+                            exchangeStatus.getChatroomId(), 0L,
+                            "교환이 예약되었습니다. 대면 교환을 진행해주세요.",
+                            "EXCHANGE_RESERVED", exchangeStatus.getExchangeStatusId())
+                    : new ExchangeRequestMessageDto(
+                            exchangeStatus.getChatroomId(), memberId,
+                            "교환 신청이 수락되었습니다.",
+                            "EXCHANGE_ACCEPTED", exchangeStatus.getExchangeStatusId());
+            chatClient.sendSystemMessage(messageDto);
+        } catch (Exception e) {
+            // 채팅 서비스 장애 시에도 교환 수락은 정상 처리
+        }
     }
 
     // 교환 요청 거절

--- a/bookhouse/src/test/java/kr/co/readingtown/bookhouse/service/ExchangeStatusServiceTest.java
+++ b/bookhouse/src/test/java/kr/co/readingtown/bookhouse/service/ExchangeStatusServiceTest.java
@@ -8,6 +8,7 @@ import kr.co.readingtown.bookhouse.dto.request.ExchangeRequestDto;
 import kr.co.readingtown.bookhouse.dto.response.AcceptExchangeResponseDto;
 import kr.co.readingtown.bookhouse.dto.response.ExchangeResponseDto;
 import kr.co.readingtown.bookhouse.exception.BookhouseException;
+import kr.co.readingtown.bookhouse.integration.chat.ChatClient;
 import kr.co.readingtown.bookhouse.repository.BookhouseRepository;
 import kr.co.readingtown.bookhouse.repository.ExchangeStatusRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,6 +26,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,247 +38,229 @@ class ExchangeStatusServiceTest {
 
     @Mock
     private ExchangeStatusRepository exchangeStatusRepository;
-    
+
+    @Mock
+    private ChatClient chatClient;
+
+    @Mock
+    private BookhouseService bookhouseService;
+
     @InjectMocks
     private ExchangeStatusService exchangeStatusService;
-    
+
     private Long memberId;
     private Long chatroomId;
     private Long exchangeStatusId;
-    
+
     @BeforeEach
     void setUp() {
         memberId = 1L;
         chatroomId = 100L;
         exchangeStatusId = 10L;
     }
-    
+
     @Test
     @DisplayName("교환 요청 생성 성공")
     void createExchangeStatus_Success() {
         // Given
         Long partnerBookhouseId = 2L;
         ExchangeRequestDto requestDto = new ExchangeRequestDto(chatroomId, partnerBookhouseId);
-        
-        // 저장될 ExchangeStatus
+
         ExchangeStatus savedStatus = ExchangeStatus.builder()
                 .chatroomId(chatroomId)
                 .bookhouseId(partnerBookhouseId)
                 .requestStatus(RequestStatus.REQUEST)
                 .build();
         setFieldValue(savedStatus, "exchangeStatusId", exchangeStatusId);
-        
-        // When - 필요한 stubbing만 설정
+
+        Bookhouse pendingBookhouse = mock(Bookhouse.class);
+        when(pendingBookhouse.getIsExchanged()).thenReturn(IsExchanged.PENDING);
+
         when(exchangeStatusRepository.existsByChatroomIdAndBookhouseId(chatroomId, partnerBookhouseId))
                 .thenReturn(false);
+        when(bookhouseRepository.findById(partnerBookhouseId))
+                .thenReturn(Optional.of(pendingBookhouse));
         when(exchangeStatusRepository.save(any(ExchangeStatus.class)))
                 .thenReturn(savedStatus);
-        
-        // Then
+
+        // When
         ExchangeResponseDto result = exchangeStatusService.createExchangeStatus(memberId, requestDto);
-        
+
+        // Then
         assertThat(result.exchangeStatusId()).isEqualTo(exchangeStatusId);
         assertThat(result.status()).isEqualTo(RequestStatus.REQUEST);
         verify(exchangeStatusRepository, times(1)).save(any(ExchangeStatus.class));
     }
-    
+
     @Test
     @DisplayName("중복 교환 요청시 예외 발생")
     void createExchangeStatus_Duplicate_ThrowsException() {
         // Given
         Long partnerBookhouseId = 2L;
         ExchangeRequestDto requestDto = new ExchangeRequestDto(chatroomId, partnerBookhouseId);
-        
-        // When
+
         when(exchangeStatusRepository.existsByChatroomIdAndBookhouseId(chatroomId, partnerBookhouseId))
                 .thenReturn(true);
-        
+
         // Then
         assertThatThrownBy(() -> exchangeStatusService.createExchangeStatus(memberId, requestDto))
                 .isInstanceOf(BookhouseException.DuplicateExchangeRequest.class);
     }
-    
+
     @Test
     @DisplayName("교환 요청 수락 - 소유자가 아니면 수락 불가")
     void acceptExchangeStatus_NonOwnerCannotAccept() {
         // Given
         Long partnerBookhouseId = 2L;
-        Long ownerId = 2L;  // 책 소유자
-        Long requesterId = 1L;  // 요청자 (소유자가 아님)
-        
-        // Mock 객체 생성
+        Long ownerId = 2L;
+        Long requesterId = 1L;
+
         ExchangeStatus mockExchangeStatus = mock(ExchangeStatus.class);
         when(mockExchangeStatus.getBookhouseId()).thenReturn(partnerBookhouseId);
-        // getRequestStatus()는 제거 - 예외 발생 전에 사용되지 않음
-        
+        when(mockExchangeStatus.getExchangeStatusId()).thenReturn(exchangeStatusId);
+
         Bookhouse mockBookhouse = mock(Bookhouse.class);
         when(mockBookhouse.getMemberId()).thenReturn(ownerId);
-        
-        // When
-        when(exchangeStatusRepository.findById(exchangeStatusId))
-                .thenReturn(Optional.of(mockExchangeStatus));
+
+        when(exchangeStatusRepository.findChatroomIdById(exchangeStatusId))
+                .thenReturn(chatroomId);
+        when(exchangeStatusRepository.findAllByChatroomIdForUpdate(chatroomId))
+                .thenReturn(List.of(mockExchangeStatus));
         when(bookhouseRepository.findById(partnerBookhouseId))
                 .thenReturn(Optional.of(mockBookhouse));
-        
-        // Then - 소유자가 아닌 사람이 수락하려 하면 예외
-        assertThatThrownBy(() -> 
+
+        // Then
+        assertThatThrownBy(() ->
                 exchangeStatusService.acceptExchangeStatus(requesterId, exchangeStatusId))
                 .isInstanceOf(BookhouseException.ForbiddenAcceptRequest.class);
     }
-    
+
     @Test
-    @DisplayName("교환 요청 수락 성공 - 소유자가 수락")
+    @DisplayName("교환 요청 수락 성공 - 한 명만 수락한 경우")
     void acceptExchangeStatus_Success() {
         // Given
         Long partnerBookhouseId = 2L;
-        Long ownerId = 2L;  // 책 소유자
-        
-        // Mock 객체 생성
+        Long ownerId = 2L;
+
         ExchangeStatus mockExchangeStatus = mock(ExchangeStatus.class);
         when(mockExchangeStatus.getBookhouseId()).thenReturn(partnerBookhouseId);
         when(mockExchangeStatus.getRequestStatus())
-                .thenReturn(RequestStatus.REQUEST)  // 처음 체크할 때
-                .thenReturn(RequestStatus.ACCEPTED); // 업데이트 후 반환할 때
+                .thenReturn(RequestStatus.REQUEST)
+                .thenReturn(RequestStatus.ACCEPTED);
         when(mockExchangeStatus.getChatroomId()).thenReturn(chatroomId);
-        
+        when(mockExchangeStatus.getExchangeStatusId()).thenReturn(exchangeStatusId);
+
         Bookhouse mockBookhouse = mock(Bookhouse.class);
         when(mockBookhouse.getMemberId()).thenReturn(ownerId);
-        
-        // When
-        when(exchangeStatusRepository.findById(exchangeStatusId))
-                .thenReturn(Optional.of(mockExchangeStatus));
+
+        when(exchangeStatusRepository.findChatroomIdById(exchangeStatusId))
+                .thenReturn(chatroomId);
+        when(exchangeStatusRepository.findAllByChatroomIdForUpdate(chatroomId))
+                .thenReturn(List.of(mockExchangeStatus));
         when(bookhouseRepository.findById(partnerBookhouseId))
                 .thenReturn(Optional.of(mockBookhouse));
-        when(exchangeStatusRepository.findAllByChatroomIdForUpdate(chatroomId))
-                .thenReturn(List.of(mockExchangeStatus));  // 1개만 수락됨
-        
-        // Then - 소유자가 수락하면 성공
+
+        // When
         AcceptExchangeResponseDto result = exchangeStatusService.acceptExchangeStatus(ownerId, exchangeStatusId);
-        
+
+        // Then
         assertThat(result.requestStatus()).isEqualTo(RequestStatus.ACCEPTED);
-        assertThat(result.isReserved()).isFalse();  // 1개만 수락이므로 false
+        assertThat(result.isReserved()).isFalse();
         verify(mockExchangeStatus).updateRequestStatus(RequestStatus.ACCEPTED);
     }
-    
+
     @Test
     @DisplayName("교환 완료 - RESERVED에서 EXCHANGED로 전환")
     void completeExchange_Success() {
-        // Given - Mock 객체 사용
+        // Given
         Bookhouse mockMyBook = mock(Bookhouse.class);
         Bookhouse mockPartnerBook = mock(Bookhouse.class);
-        
+
         when(mockMyBook.getIsExchanged()).thenReturn(IsExchanged.RESERVED);
         when(mockPartnerBook.getIsExchanged()).thenReturn(IsExchanged.RESERVED);
-        
-        ExchangeStatus status1 = createExchangeStatus(1L, chatroomId, 1L, RequestStatus.ACCEPTED);
-        ExchangeStatus status2 = createExchangeStatus(2L, chatroomId, 2L, RequestStatus.ACCEPTED);
-        
+
+        when(bookhouseRepository.findAllByChatroomIdForUpdate(chatroomId))
+                .thenReturn(Arrays.asList(mockMyBook, mockPartnerBook));
+
         // When
-        when(exchangeStatusRepository.findByChatroomId(chatroomId))
-                .thenReturn(Arrays.asList(status1, status2));
-        when(bookhouseRepository.findById(1L))
-                .thenReturn(Optional.of(mockMyBook));
-        when(bookhouseRepository.findById(2L))
-                .thenReturn(Optional.of(mockPartnerBook));
-        
-        // Then
         exchangeStatusService.completeExchange(chatroomId);
-        
-        // Mock 객체에 대해서만 verify 사용
+
+        // Then
         verify(mockMyBook).updateIsExchanged(IsExchanged.EXCHANGED);
         verify(mockPartnerBook).updateIsExchanged(IsExchanged.EXCHANGED);
     }
-    
+
     @Test
     @DisplayName("교환 완료 실패 - 2개가 아닌 경우")
     void completeExchange_InvalidCount_ThrowsException() {
         // Given
-        ExchangeStatus status1 = createExchangeStatus(1L, chatroomId, 1L, RequestStatus.ACCEPTED);
-        
-        // When - 1개만 있는 경우
-        when(exchangeStatusRepository.findByChatroomId(chatroomId))
-                .thenReturn(List.of(status1));
-        
+        Bookhouse mockBook = mock(Bookhouse.class);
+
+        when(bookhouseRepository.findAllByChatroomIdForUpdate(chatroomId))
+                .thenReturn(List.of(mockBook));
+
         // Then
         assertThatThrownBy(() -> exchangeStatusService.completeExchange(chatroomId))
                 .isInstanceOf(BookhouseException.InvalidExchangeStatusCount.class);
     }
-    
+
     @Test
     @DisplayName("교환 완료 실패 - RESERVED 상태가 아닌 경우")
     void completeExchange_NotReserved_ThrowsException() {
         // Given
-        Bookhouse mockBook = mock(Bookhouse.class);
-        when(mockBook.getIsExchanged()).thenReturn(IsExchanged.PENDING);  // RESERVED가 아님
-        
-        ExchangeStatus status1 = createExchangeStatus(1L, chatroomId, 1L, RequestStatus.ACCEPTED);
-        ExchangeStatus status2 = createExchangeStatus(2L, chatroomId, 2L, RequestStatus.ACCEPTED);
-        
-        // When
-        when(exchangeStatusRepository.findByChatroomId(chatroomId))
-                .thenReturn(Arrays.asList(status1, status2));
-        when(bookhouseRepository.findById(1L))
-                .thenReturn(Optional.of(mockBook));
-        
+        Bookhouse mockBook1 = mock(Bookhouse.class);
+        Bookhouse mockBook2 = mock(Bookhouse.class);
+        when(mockBook1.getIsExchanged()).thenReturn(IsExchanged.PENDING);
+
+        when(bookhouseRepository.findAllByChatroomIdForUpdate(chatroomId))
+                .thenReturn(Arrays.asList(mockBook1, mockBook2));
+
         // Then
         assertThatThrownBy(() -> exchangeStatusService.completeExchange(chatroomId))
                 .isInstanceOf(BookhouseException.InvalidExchangeStatusForComplete.class);
     }
-    
+
     @Test
     @DisplayName("반납 완료 - EXCHANGED에서 PENDING으로 전환")
     void returnExchange_Success() {
-        // Given - Mock 객체 사용
+        // Given
         Bookhouse mockMyBook = mock(Bookhouse.class);
         Bookhouse mockPartnerBook = mock(Bookhouse.class);
-        
+
         when(mockMyBook.getIsExchanged()).thenReturn(IsExchanged.EXCHANGED);
         when(mockPartnerBook.getIsExchanged()).thenReturn(IsExchanged.EXCHANGED);
-        
-        ExchangeStatus status1 = createExchangeStatus(1L, chatroomId, 1L, RequestStatus.ACCEPTED);
-        ExchangeStatus status2 = createExchangeStatus(2L, chatroomId, 2L, RequestStatus.ACCEPTED);
-        
-        // When  
-        when(exchangeStatusRepository.findByChatroomId(chatroomId))
-                .thenReturn(Arrays.asList(status1, status2));
-        when(bookhouseRepository.findById(1L))
-                .thenReturn(Optional.of(mockMyBook));
-        when(bookhouseRepository.findById(2L))
-                .thenReturn(Optional.of(mockPartnerBook));
-        
-        // Then
+
+        when(bookhouseRepository.findAllByChatroomIdForUpdate(chatroomId))
+                .thenReturn(Arrays.asList(mockMyBook, mockPartnerBook));
+
+        // When
         exchangeStatusService.returnExchange(chatroomId);
-        
-        // Mock 객체에 대해서만 verify 사용
+
+        // Then
         verify(mockMyBook).updateIsExchanged(IsExchanged.PENDING);
         verify(mockPartnerBook).updateIsExchanged(IsExchanged.PENDING);
         verify(mockMyBook).updateChatroomId(null);
         verify(mockPartnerBook).updateChatroomId(null);
     }
-    
-    @Test  
+
+    @Test
     @DisplayName("반납 실패 - EXCHANGED 상태가 아닌 경우")
     void returnExchange_NotExchanged_ThrowsException() {
         // Given
-        Bookhouse mockBook = mock(Bookhouse.class);
-        when(mockBook.getIsExchanged()).thenReturn(IsExchanged.RESERVED);  // EXCHANGED가 아님
-        
-        ExchangeStatus status1 = createExchangeStatus(1L, chatroomId, 1L, RequestStatus.ACCEPTED);
-        ExchangeStatus status2 = createExchangeStatus(2L, chatroomId, 2L, RequestStatus.ACCEPTED);
-        
-        // When
-        when(exchangeStatusRepository.findByChatroomId(chatroomId))
-                .thenReturn(Arrays.asList(status1, status2));
-        when(bookhouseRepository.findById(1L))
-                .thenReturn(Optional.of(mockBook));
-        
+        Bookhouse mockBook1 = mock(Bookhouse.class);
+        Bookhouse mockBook2 = mock(Bookhouse.class);
+        when(mockBook1.getIsExchanged()).thenReturn(IsExchanged.RESERVED);
+
+        when(bookhouseRepository.findAllByChatroomIdForUpdate(chatroomId))
+                .thenReturn(Arrays.asList(mockBook1, mockBook2));
+
         // Then
         assertThatThrownBy(() -> exchangeStatusService.returnExchange(chatroomId))
                 .isInstanceOf(BookhouseException.InvalidExchangeStatusForReturn.class);
     }
-    
+
     // === 헬퍼 메소드 ===
-    
+
     private ExchangeStatus createExchangeStatus(Long id, Long chatroomId, Long bookhouseId, RequestStatus status) {
         ExchangeStatus es = ExchangeStatus.builder()
                 .chatroomId(chatroomId)
@@ -286,7 +270,7 @@ class ExchangeStatusServiceTest {
         setFieldValue(es, "exchangeStatusId", id);
         return es;
     }
-    
+
     private void setFieldValue(Object obj, String fieldName, Object value) {
         try {
             Field field = obj.getClass().getDeclaredField(fieldName);


### PR DESCRIPTION
## ✨ Issue Number
> close #231 

## 📄 작업 내용 (주요 변경 사항)

## 문제

  기존 코드는 수락 처리 시 아래 순서로 락을 획득했습니다.

  1. `findByIdForUpdate` → 단일 행 락 획득
  2. `findAllByChatroomIdForUpdate` → 채팅방 전체 행 락 획득

  동시에 두 사용자가 각자의 ExchangeStatus 행에 단일 행 락을 잡은 뒤, 서로 상대방 행을 포함한 전체 행 락을 요청하면 **교착
  상태(Deadlock)** 가 발생합니다.

  ## 해결

  채팅방 ID는 불변 값이므로 락 없이 조회해도 안전합니다.

  1. `findChatroomIdById` → chatroomId만 조회 (락 없음)
  2. `findAllByChatroomIdForUpdate` → 채팅방 전체 행을 한 번에 락 획득

  락을 한 번만, 채팅방 단위로 획득함으로써 데드락 가능성을 제거했습니다.

  ## 변경 사항

  - `ExchangeStatusRepository` — `findChatroomIdById` 쿼리 메서드 추가
  - `ExchangeStatusService` — `acceptExchangeStatus` 데드락 수정, private 메서드 분리 (`lockChatroomAndGetAll`, `findFromLocked`,
  `validateAcceptPermission`, `tryReserve`, `sendAcceptMessage`)
  - `ExchangeStatusServiceTest` — 기존 테스트 버그 수정 (잘못된 stub, 누락된 mock 추가)

  ## 테스트

  - 전체 9개 단위 테스트 통과

## 💬 리뷰 요구사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 책 교환 수락 프로세스의 동시성 제어를 강화하여 예약 충돌을 방지했습니다.
  * 교환 상태 검증 및 오류 처리 로직을 개선했습니다.

* **테스트**
  * 교환 상태 서비스 관련 테스트를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->