### PR TITLE
fix: 동네 유저 추천 성능 개선 - 바운딩 박스 쿼리 및 위치 인덱스 추가

### DIFF
--- a/member/src/main/java/kr/co/readingtown/member/domain/Member.java
+++ b/member/src/main/java/kr/co/readingtown/member/domain/Member.java
@@ -11,7 +11,10 @@ import java.math.BigDecimal;
 
 @Entity
 @Getter
-@Table(name = "members")
+@Table(
+    name = "members",
+    indexes = @Index(name = "idx_member_location", columnList = "latitude, longitude")
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 

--- a/member/src/main/java/kr/co/readingtown/member/repository/MemberRepository.java
+++ b/member/src/main/java/kr/co/readingtown/member/repository/MemberRepository.java
@@ -7,8 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
+import java.math.BigDecimal;
 import java.util.List;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -37,9 +36,22 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("""
     SELECT m
     FROM Member m
-    WHERE m.latitude IS NOT NULL 
+    WHERE m.latitude IS NOT NULL
     AND m.longitude IS NOT NULL
     AND m.isOnboarded = true
     """)
     List<Member> findAllWithLocation();
+
+    @Query("""
+    SELECT m
+    FROM Member m
+    WHERE m.latitude BETWEEN :minLat AND :maxLat
+    AND m.longitude BETWEEN :minLon AND :maxLon
+    """)
+    List<Member> findMembersInBoundingBox(
+            @Param("minLat") BigDecimal minLat,
+            @Param("maxLat") BigDecimal maxLat,
+            @Param("minLon") BigDecimal minLon,
+            @Param("maxLon") BigDecimal maxLon
+    );
 }

--- a/member/src/main/java/kr/co/readingtown/member/service/RecommendationService.java
+++ b/member/src/main/java/kr/co/readingtown/member/service/RecommendationService.java
@@ -119,20 +119,32 @@ public class RecommendationService {
     public List<LocalMemberRecommendationDto> recommendLocalMembers(Long memberId) {
         Member currentMember = memberRepository.findById(memberId)
                 .orElseThrow(MemberException.NotFoundMember::new);
-        
+
         if (currentMember.getLatitude() == null || currentMember.getLongitude() == null) {
             return List.of();
         }
-        
-        List<Member> allMembers = memberRepository.findAllWithLocation();
-        
-        return allMembers.stream()
+
+        // 바운딩 박스 계산 (반경 1km)
+        final double RADIUS_KM = 1.0;
+        final double LAT_DEGREE_PER_KM = 1.0 / 110.574;
+        double currentLat = currentMember.getLatitude().doubleValue();
+        double currentLon = currentMember.getLongitude().doubleValue();
+        double latDelta = RADIUS_KM * LAT_DEGREE_PER_KM;
+        double lonDelta = RADIUS_KM / (111.320 * Math.cos(Math.toRadians(currentLat)));
+
+        BigDecimal minLat = BigDecimal.valueOf(currentLat - latDelta);
+        BigDecimal maxLat = BigDecimal.valueOf(currentLat + latDelta);
+        BigDecimal minLon = BigDecimal.valueOf(currentLon - lonDelta);
+        BigDecimal maxLon = BigDecimal.valueOf(currentLon + lonDelta);
+
+        List<Member> allMembers = memberRepository.findMembersInBoundingBox(minLat, maxLat, minLon, maxLon);
+
+        List<LocalMemberRecommendationDto> result = allMembers.stream()
                 .filter(member -> !member.getMemberId().equals(memberId))
-                .filter(member -> member.getLatitude() != null && member.getLongitude() != null)
                 .map(member -> {
                     double distance = calculateDistance(
-                            currentMember.getLatitude().doubleValue(),
-                            currentMember.getLongitude().doubleValue(),
+                            currentLat,
+                            currentLon,
                             member.getLatitude().doubleValue(),
                             member.getLongitude().doubleValue()
                     );
@@ -141,6 +153,8 @@ public class RecommendationService {
                 .sorted(Comparator.comparing(LocalMemberRecommendationDto::distanceKm))
                 .limit(10)
                 .collect(Collectors.toList());
+
+        return result;
     }
     
     /**


### PR DESCRIPTION
## ✨ Issue Number
> close #233 

## 📄 작업 내용 (주요 변경 사항)

## Summary

  - 기존 `findAllWithLocation()`으로 위치 정보가 있는 전체 멤버를 조회하던 방식을 **바운딩 박스 쿼리**로 교체하여 DB 레벨에서 1km
  반경 후보만 필터링
  - `Member` 엔티티에 `(latitude, longitude)` 복합 인덱스(`idx_member_location`) 추가
  - 우선순위 큐 도입하려했으나, 애초에 바운딩 쿼리로 후보군이 줄었기 때문에 List sort가 더 적합!

  ## Changes

  - `RecommendationService`: Haversine 거리 계산 전 바운딩 박스로 1차 필터링
  - `MemberRepository`: `findMembersInBoundingBox()` 쿼리 추가
  - `Member`: `@Table` 에 `(latitude, longitude)` 복합 인덱스 추가

## 💬 리뷰 요구사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 주변 지역 회원 검색 및 추천 기능의 응답 속도가 향상되었습니다.
  * 위치 기반 데이터 조회 처리가 최적화되어 시스템 효율성이 개선되었습니다.
  * 지역별 회원 추천 기능이 더욱 빠르고 안정적으로 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->